### PR TITLE
Update Windows driver code based on CodeQL analysis findings

### DIFF
--- a/src/windows/filter/qcfilter.c
+++ b/src/windows/filter/qcfilter.c
@@ -361,7 +361,7 @@ QCFilterDispatchPnp(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 KeInitializeEvent(&event, NotificationEvent, FALSE);
                 IoCopyCurrentIrpStackLocationToNext(Irp);
                 IoSetCompletionRoutine(Irp,
-                    (PIO_COMPLETION_ROUTINE)QCFilterStartCompletionRoutine,
+                    QCFilterStartCompletionRoutine,
                     &event,
                     TRUE,
                     TRUE,
@@ -1797,7 +1797,7 @@ Success:
                                     IoCopyCurrentIrpStackLocationToNext(Irp);
 
                                     IoSetCompletionRoutine(Irp,
-                                                (PIO_COMPLETION_ROUTINE) QCFLT_GetConfigurationCompletion,
+                                                QCFLT_GetConfigurationCompletion,
                                         &event, TRUE, TRUE, TRUE);
 
                                     status = IoCallDriver(deviceExtension->NextLowerDriver, Irp);
@@ -1821,7 +1821,7 @@ Success:
                                         IoCopyCurrentIrpStackLocationToNext(Irp);
 
                                         IoSetCompletionRoutine(Irp,
-                                            (PIO_COMPLETION_ROUTINE) QCFLT_GetConfigurationCompletion,
+                                            QCFLT_GetConfigurationCompletion,
                                             &event, TRUE, TRUE, TRUE);
 
                                         status = IoCallDriver(deviceExtension->NextLowerDriver, Irp);
@@ -1857,7 +1857,7 @@ Success:
                                         IoCopyCurrentIrpStackLocationToNext(Irp);
 
                                         IoSetCompletionRoutine(Irp,
-                                            (PIO_COMPLETION_ROUTINE) QCFLT_GetConfigurationCompletion,
+                                            QCFLT_GetConfigurationCompletion,
                                             &event, TRUE, TRUE, TRUE);
 
                                         status = IoCallDriver(deviceExtension->NextLowerDriver, Irp);

--- a/src/windows/filter/qcfilter.c
+++ b/src/windows/filter/qcfilter.c
@@ -3007,45 +3007,6 @@ getRegDwValueEntryData_Return:
     return ntStatus;
 }
 
-/******************************************************************************************
-* Function Name: getRegSzValueEntryData
-* Arguments:
-*
-*  IN HANDLE OpenRegKey,
-*  IN PWSTR ValueEntryName,
-*  OUT PULONG pValueEntryData
-*
-*******************************************************************************************/
-NTSTATUS getRegSzValueEntryData
-(
-    IN HANDLE OpenRegKey,
-    IN PWSTR ValueEntryName,
-    OUT PCHAR pValueEntryData
-)
-{
-    NTSTATUS ntStatus = STATUS_SUCCESS;
-    PKEY_VALUE_FULL_INFORMATION pKeyValueInfo = NULL;
-
-   ntStatus = QCFLT_GetValueEntry( OpenRegKey, ValueEntryName, &pKeyValueInfo );
-
-    if (!NT_SUCCESS(ntStatus))
-    {
-        goto getRegSzValueEntryData_Return;
-    }
-
-   QCFLT_GetSzField( pKeyValueInfo, pValueEntryData);
-
-getRegSzValueEntryData_Return:
-
-    if (pKeyValueInfo)
-    {
-        _ExFreePool(pKeyValueInfo);
-        pKeyValueInfo = NULL;
-    }
-
-    return ntStatus;
-}
-
 /************************************************************************
 Routine Description:
    Return a KEY_VALUE information from an open registry node
@@ -3142,28 +3103,6 @@ ULONG QCFLT_GetDwordField( PKEY_VALUE_FULL_INFORMATION pKvi )
     pVal = (PULONG)((PCHAR)pKvi + pKvi->DataOffset);
     dwVal = *pVal;
     return dwVal;
-}
-
-/************************************************************************
-Routine Description:
-   Return a Sz value from an open registry node
-
-Arguments:
-   pKvi -- node key information
-
-Returns:
-   Sz value of the value entry
-
-************************************************************************/
-VOID QCFLT_GetSzField( PKEY_VALUE_FULL_INFORMATION pKvi, PCHAR ValueEntryDataSz  )
-{
-    UNICODE_STRING unicodeStr;
-    ANSI_STRING    ansiStr;
-    PWSTR strPtr = (PWSTR)((PCHAR)pKvi + pKvi->DataOffset);
-    RtlInitUnicodeString(&unicodeStr, strPtr);
-    RtlUnicodeStringToAnsiString(&ansiStr, &unicodeStr, TRUE);
-    strcpy(ValueEntryDataSz, ansiStr.Buffer);
-    RtlFreeAnsiString(&ansiStr);
 }
 
 /************************************************************************

--- a/src/windows/filter/qcfilter.c
+++ b/src/windows/filter/qcfilter.c
@@ -114,9 +114,12 @@ DriverEntry(PDRIVER_OBJECT  driverObject, PUNICODE_STRING registryPath)
     RtlZeroMemory(gDeviceName, 255);
     if ((strlen(p) == 0) || (strlen(p) >= 255)) // invalid name
     {
-        strcpy(gDeviceName, (char *)"filter_unknown");
+        strcpy_s(gDeviceName, sizeof(gDeviceName), (char *)"filter_unknown");
     }
-    strcpy(gDeviceName, p);
+    else
+    {
+        strcpy_s(gDeviceName, sizeof(gDeviceName), p);
+    }
 
     // Free the allocated string
     RtlFreeAnsiString(&asDevName);
@@ -744,7 +747,7 @@ QCFilterCreateControlObject(PDEVICE_OBJECT    DeviceObject, PFILTER_DEVICE_INFO 
         deviceExtension->Self = pFilterDeviceInfo->pControlDeviceObject;
         deviceExtension->DriverObject = DeviceObject->DriverObject;
         deviceExtension->FidoDeviceObject = DeviceObject;
-        strcpy(deviceExtension->PortName, pDevExt->PortName);
+        strcpy_s(deviceExtension->PortName, sizeof(deviceExtension->PortName), pDevExt->PortName);
         deviceExtension->DebugMask = pDevExt->DebugMask;
         deviceExtension->DebugLevel = pDevExt->DebugLevel;
         pDevExt->ControlDeviceObject = pFilterDeviceInfo->pControlDeviceObject;
@@ -2416,7 +2419,7 @@ QCFLT_AddControlDevice
 
     QcAcquireSpinLock(&Control_DeviceLock, &levelOrHandle);
 
-    pIocDev = ExAllocatePool(NonPagedPool, sizeof(FILTER_DEVICE_LIST));
+    pIocDev = _ExAllocatePool(NonPagedPoolNx, sizeof(FILTER_DEVICE_LIST), 'coip');
     if (pIocDev == NULL)
     {
         QCFLT_DbgPrint
@@ -2427,10 +2430,9 @@ QCFLT_AddControlDevice
         QcReleaseSpinLock(&Control_DeviceLock, levelOrHandle);
         return STATUS_UNSUCCESSFUL;
     }
-    RtlZeroMemory(pIocDev, sizeof(FILTER_DEVICE_LIST));
     pIocDev->pAdapter = pFilterDeviceInfo->pAdapter;
 
-    pIocDev->DeviceName.Buffer = (PWSTR)_ExAllocatePool(NonPagedPool, pFilterDeviceInfo->pDeviceName->Length, "NAME");
+    pIocDev->DeviceName.Buffer = (PWSTR)_ExAllocatePool(NonPagedPoolNx, pFilterDeviceInfo->pDeviceName->Length, 'eman');
     if (pIocDev->DeviceName.Buffer == NULL)
     {
         QCFLT_DbgPrint
@@ -2445,7 +2447,7 @@ QCFLT_AddControlDevice
         RtlCopyUnicodeString(&pIocDev->DeviceName, pFilterDeviceInfo->pDeviceName);
     }
 
-    pIocDev->DeviceLinkName.Buffer = (PWSTR)_ExAllocatePool(NonPagedPool, pFilterDeviceInfo->pDeviceLinkName->Length, "NAME");
+    pIocDev->DeviceLinkName.Buffer = (PWSTR)_ExAllocatePool(NonPagedPoolNx, pFilterDeviceInfo->pDeviceLinkName->Length, 'eman');
     if (pIocDev->DeviceLinkName.Buffer == NULL)
     {
         QCFLT_DbgPrint
@@ -2960,7 +2962,7 @@ NTSTATUS QCFLT_VendorRegistryProcess
     _closeHandle(hRegKey, "PNP-2");
 
     // Store the correct device name
-    sprintf(pDevExt->PortName, "%s%d", gDeviceName, gDeviceIndex);
+    sprintf_s(pDevExt->PortName, sizeof(pDevExt->PortName), "%s%d", gDeviceName, gDeviceIndex);
     InterlockedIncrement(&gDeviceIndex);
 
     return STATUS_SUCCESS;
@@ -3074,15 +3076,15 @@ NTSTATUS QCFLT_GetValueEntry( HANDLE hKey, PWSTR FieldName, PKEY_VALUE_FULL_INFO
     while (1)
     {
         pKeyValueInfo = (PKEY_VALUE_FULL_INFORMATION)_ExAllocatePool(
-            NonPagedPool,
+            NonPagedPoolNx,
             ulBuffLength,
-            "GetValueEntry - 2");
+            'vyek');
 
         if (pKeyValueInfo == NULL)
         {
             *pKeyValInfo = NULL;
             ntStatus = STATUS_NO_MEMORY;
-            goto QCFLT_GetValueEntry_Return; 
+            goto QCFLT_GetValueEntry_Return;
         }
 
         ntStatus = ZwQueryValueKey(
@@ -3216,13 +3218,12 @@ VOID QCFLT_PrintBytes
 
     buffer = (char *)Buf;
 
-    dbgOutputBuffer = ExAllocatePool(NonPagedPool, myTextSize);
+    dbgOutputBuffer = _ExAllocatePool(NonPagedPoolNx, myTextSize, 'ogbd');
     if (dbgOutputBuffer == NULL)
     {
         return;
     }
 
-    RtlZeroMemory(dbgOutputBuffer, myTextSize);
     cBuf = dbgOutputBuffer;
     buf = dbgOutputBuffer + 128;
     p = buf;
@@ -3233,18 +3234,18 @@ VOID QCFLT_PrintBytes
         len = PktLen;
     }
 
-    sprintf(p, "\r\n\t   --- <%s> DATA %u/%u BYTES ---\r\n", info, len, PktLen);
+    sprintf_s(p, (size_t)(myTextSize - (p - dbgOutputBuffer)), "\r\n\t   --- <%s> DATA %u/%u BYTES ---\r\n", info, len, PktLen);
     p += strlen(p);
 
     for (i = 1; i <= len; i++)
     {
         if (i % 16 == 1)
         {
-            sprintf(p, "  %04u:  ", i - 1);
+            sprintf_s(p, (size_t)(myTextSize - (p - dbgOutputBuffer)), "  %04u:  ", i - 1);
             p += 9;
         }
 
-        sprintf(p, "%02X ", (UCHAR)buffer[i - 1]);
+        sprintf_s(p, (size_t)(myTextSize - (p - dbgOutputBuffer)), "%02X ", (UCHAR)buffer[i - 1]);
         if (isprint(buffer[i - 1]) && (!isspace(buffer[i - 1])))
         {
             *cp = buffer[i - 1]; // sprintf(cp, "%c", buffer[i-1]);
@@ -3267,11 +3268,11 @@ VOID QCFLT_PrintBytes
         {
             if (i % 64 == 0)
             {
-                sprintf(p, " %c  %s\r\n\r\n", SPLIT_CHAR, cBuf);
+                sprintf_s(p, (size_t)(myTextSize - (p - dbgOutputBuffer)), " %c  %s\r\n\r\n", SPLIT_CHAR, cBuf);
             }
             else
             {
-                sprintf(p, " %c  %s\r\n", SPLIT_CHAR, cBuf);
+                sprintf_s(p, (size_t)(myTextSize - (p - dbgOutputBuffer)), " %c  %s\r\n", SPLIT_CHAR, cBuf);
             }
 
             QCFLT_DbgPrint
@@ -3305,7 +3306,7 @@ VOID QCFLT_PrintBytes
         {
             *p++ = ' '; // sprintf(p++, " ");
         }
-        sprintf(p, " %c  %s\r\n\t   --- <%s> END OF DATA BYTES(%u/%uB) ---\n",
+        sprintf_s(p, (size_t)(myTextSize - (p - dbgOutputBuffer)), " %c  %s\r\n\t   --- <%s> END OF DATA BYTES(%u/%uB) ---\n",
             SPLIT_CHAR, cBuf, info, len, PktLen);
         QCFLT_DbgPrint
         (
@@ -3315,7 +3316,7 @@ VOID QCFLT_PrintBytes
     }
     else
     {
-        sprintf(buf, "\r\n\t   --- <%s> END OF DATA BYTES(%u/%uB) ---\n", info, len, PktLen);
+        sprintf_s(buf, (size_t)(myTextSize - (buf - dbgOutputBuffer)), "\r\n\t   --- <%s> END OF DATA BYTES(%u/%uB) ---\n", info, len, PktLen);
         QCFLT_DbgPrint
         (
             DBG_LEVEL_VERBOSE,

--- a/src/windows/filter/qcfilter.h
+++ b/src/windows/filter/qcfilter.h
@@ -448,18 +448,9 @@ NTSTATUS getRegDwValueEntryData
     OUT PULONG pValueEntryData
 );
 
-NTSTATUS getRegSzValueEntryData
-(
-    IN HANDLE OpenRegKey,
-    IN PWSTR ValueEntryName,
-    OUT PCHAR pValueEntryData
-);
-
 NTSTATUS QCFLT_GetValueEntry( HANDLE hKey, PWSTR FieldName, PKEY_VALUE_FULL_INFORMATION  *pKeyValInfo );
 
 ULONG QCFLT_GetDwordField( PKEY_VALUE_FULL_INFORMATION pKvi );
-
-VOID QCFLT_GetSzField(PKEY_VALUE_FULL_INFORMATION pKvi, PCHAR ValueEntryDataSz);
 
 BOOLEAN USBPNP_ValidateConfigDescriptor
 (

--- a/src/windows/filter/qcfilter.h
+++ b/src/windows/filter/qcfilter.h
@@ -173,7 +173,7 @@ typedef enum _QC_DEVICE_PNP_STATE
            } \
         }
 
-#define _ExAllocatePool(a,b,c) ExAllocatePool(a,b)
+#define _ExAllocatePool(a,b,c) ExAllocatePoolZero(a,b,c)
 #define _ExFreePool(_a) { ExFreePool(_a); _a=NULL; }
 
 #define _freeBuf(_a) \

--- a/src/windows/filter/qcfilter.h
+++ b/src/windows/filter/qcfilter.h
@@ -394,11 +394,13 @@ __drv_dispatchType(IRP_MJ_READ)
 __drv_dispatchType(IRP_MJ_WRITE)
 DRIVER_DISPATCH QCFilterDispatchIo;
 
-PCHAR QCPnPMinorFunctionString(UCHAR MinorFunction);
+DRIVER_CANCEL QCFLT_DispatchCancelQueued;
 
-NTSTATUS QCFilterStartCompletionRoutine(PDEVICE_OBJECT DeviceObject, PIRP Irp, PVOID Context);
+IO_COMPLETION_ROUTINE QCFilterStartCompletionRoutine;
 
-NTSTATUS QCFilterQueryCapabilitiesCompletionRoutine(PDEVICE_OBJECT DeviceObject, PIRP Irp, PVOID Context);
+IO_COMPLETION_ROUTINE QCFLT_CallUSBD_Completion;
+
+IO_COMPLETION_ROUTINE QCFLT_GetConfigurationCompletion;
 
 NTSTATUS
 QCFilterCreateControlObject(PDEVICE_OBJECT DeviceObject, PFILTER_DEVICE_INFO pFilterDeviceInfo);

--- a/src/windows/filter/qcfilterioc.c
+++ b/src/windows/filter/qcfilterioc.c
@@ -251,9 +251,9 @@ QCFLT_ControlFilterThread(PVOID pContext)
     // allocate a wait block array for the multiple wait
     pwbArray = _ExAllocatePool
     (
-        NonPagedPool,
+        NonPagedPoolNx,
         (QCFLT_FILTER_EVENT_COUNT + 1) * sizeof(KWAIT_BLOCK),
-        "Flt.pwbArray"
+        'abwp'
     );
     if (pwbArray == NULL)
     {

--- a/src/windows/ndis/MPIOC.c
+++ b/src/windows/ndis/MPIOC.c
@@ -25,7 +25,7 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "MPIOC.tmh"
 
 #endif   // EVENT_TRACING
@@ -43,7 +43,7 @@ extern NTKERNELAPI NTSTATUS ZwSetSecurityObject
    IN HANDLE                Handle,
    IN SECURITY_INFORMATION  SecurityInformation,
    IN PSECURITY_DESCRIPTOR  SecurityDescriptor
-); 
+);
 
 NDIS_STATUS MPIOC_RegisterDevice
 (
@@ -91,9 +91,9 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
     ANSI_STRING        ansiString;
 
     irpStack = IoGetCurrentIrpStackLocation(Irp);
-    
+
     fileObj = irpStack->FileObject;
-    
+
     if (fileObj->FileName.Length != 0)
     {
        RtlUnicodeStringToAnsiString(&ansiString, &(fileObj->FileName), TRUE);
@@ -108,7 +108,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
        }
        RtlFreeAnsiString(&ansiString);
     }
-    
+
     pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, Irp, QMIType);
     if (pIocDev == NULL)
     {
@@ -157,7 +157,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              PsGetCurrentProcessId(), DeviceObject, pIocDev, pIocDev->Type, Irp->CurrentLocation, Irp->StackCount, DeviceObject->StackSize)
           );
 
-#if 0 
+#if 0
           if (pIocDev->SecurityReset == 0)
           {
              status = STATUS_SUCCESS;
@@ -168,7 +168,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
           NdisAcquireSpinLock(MP_CtlLock);
 
           InterlockedIncrement(&(pIocDev->DeviceOpenCount));
-#if 0          
+#if 0
           KeClearEvent(&pIocDev->ClientClosedEvent);
 #endif
           NdisReleaseSpinLock(MP_CtlLock);
@@ -224,11 +224,11 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                          (pIocDev->ClientId != 0) )
                    {
                        USHORT ReqType = QMIWDS_BIND_MUX_DATA_PORT_REQ;
-                       if (pIocDev->QMIType == QMUX_TYPE_QOS) 
+                       if (pIocDev->QMIType == QMUX_TYPE_QOS)
                        {
                           ReqType = QMI_QOS_BIND_DATA_PORT_REQ;
                        }
-                       if (pIocDev->QMIType == QMUX_TYPE_DFS) 
+                       if (pIocDev->QMIType == QMUX_TYPE_DFS)
                        {
                           ReqType = QMIDFS_BIND_CLIENT_REQ;
                        }
@@ -328,7 +328,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
           {
              NdisAcquireSpinLock(MP_CtlLock);
              if (pIocDev->GetServiceFileIrp != NULL)
-             { 
+             {
                 PIRP pIrp = pIocDev->GetServiceFileIrp;
 
                 QCNET_DbgPrintG(("GetServiceFileIrp NULL for 0x%p - 3\n", pIocDev));
@@ -457,12 +457,12 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
           {
              MPIOC_DeleteFilterDevice(pAdapter, pIocDev,NULL);
           }
-          
-          
-          break;        
+
+
+          break;
        }
 
-       case IRP_MJ_DEVICE_CONTROL: 
+       case IRP_MJ_DEVICE_CONTROL:
        {
           QCNET_DbgPrint
           (
@@ -481,9 +481,9 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              );
              break;
           }
-#endif          
+#endif
 
-          buffer = Irp->AssociatedIrp.SystemBuffer;  
+          buffer = Irp->AssociatedIrp.SystemBuffer;
           inlen = irpStack->Parameters.DeviceIoControl.InputBufferLength;
           outlen = irpStack->Parameters.DeviceIoControl.OutputBufferLength;
 
@@ -521,7 +521,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                    QCNET_DbgPrint
                    (
                       MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
-                      ("<%s> IOCTL_QCDEV_GET_SERVICE_FILE: QMI Type 0x%x\n", 
+                      ("<%s> IOCTL_QCDEV_GET_SERVICE_FILE: QMI Type 0x%x\n",
                         pAdapter->PortName, qmiType)
                    );
 
@@ -563,14 +563,14 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 
                    // Create the IOCDEV
                    //pFreeIocDev = MPIOC_FindFreeClientObject(DeviceObject);
-                   
-                   RtlStringCchPrintfExA( ClientFileName, 
+
+                   RtlStringCchPrintfExA( ClientFileName,
                                           IOCDEV_CLIENT_FILE_NAME_LEN,
                                           NULL,
                                           NULL,
                                           STRSAFE_IGNORE_NULLS,
-                                          "%s\\%d", 
-                                          pIocDev->ClientFileName, 
+                                          "%s\\%d",
+                                          pIocDev->ClientFileName,
                                           qmiType);
                    MPIOC_AddDevice
                    (
@@ -600,7 +600,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 
                    // Init QMI if it's not initialized
                    if (FALSE == MPMAIN_InitializeQMI(pAdapter, QMICTL_RETRIES))
-                   { 
+                   {
                       QCNET_DbgPrint
                       (
                          MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
@@ -671,13 +671,13 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                       else
                       {
                          ++cf;
-                         RtlStringCchPrintfExA( ClientFileName, 
+                         RtlStringCchPrintfExA( ClientFileName,
                                                 IOCDEV_CLIENT_FILE_NAME_LEN,
                                                 NULL,
                                                 NULL,
                                                 STRSAFE_IGNORE_NULLS,
-                                                "%s\\%d", 
-                                                cf, 
+                                                "%s\\%d",
+                                                cf,
                                                 qmiType);
                       }
                       QCNET_DbgPrint
@@ -737,7 +737,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: IOCTL_QCDEV_GET_SERVICE_FILE wrong DO type\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -752,7 +752,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for GET_CID\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -777,7 +777,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: requested wrong dev for GET_CID\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -874,7 +874,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 }
 
                 MPQCTL_GetQMICTLVersion(pAdapter, FALSE);
-                
+
                 verPtr = (PQMI_SERVICE_VERSION)buffer;
                 verPtr->Major = pAdapter->QMUXVersion[qmiType].Major;
                 verPtr->Minor = pAdapter->QMUXVersion[qmiType].Minor;
@@ -889,7 +889,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                    {
                       labelLen = 255;
                    }
-                   RtlCopyMemory(pLabel, pAdapter->AddendumVersionLabel, labelLen); 
+                   RtlCopyMemory(pLabel, pAdapter->AddendumVersionLabel, labelLen);
                    Irp->IoStatus.Information = sizeof(QMI_SERVICE_VERSION) + labelLen;
                 }
                 else
@@ -913,7 +913,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for UMSK\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -943,7 +943,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                    Irp->IoStatus.Information = sizeof(ULONG);
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_FORCE, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_FORCE,
                       ("<%s> MP: new DbgMask 0x%x(L%d)\n", pAdapter->PortName,
                         pAdapter->DebugMask, pAdapter->DebugLevel)
                    );
@@ -993,7 +993,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 // to handle MTU notifications only
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_WAIT_NOTIFY, fileObj 0x%p Ioc 0x%p\n", pAdapter->PortName, irpStack->FileObject, pIocDev)
                 );
 
@@ -1030,7 +1030,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for GET_MEID\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -1044,14 +1044,14 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 }
                 break;
              }
-             
+
              case IOCTL_QCDEV_DEVICE_REMOVE_EVENTA:
              {
                 if ((buffer == NULL) || (inlen == 0) || (outlen == 0) || (outlen < sizeof(ULONGLONG)) || (pAdapter->NamedEventsIndex >= DEVICE_REMOVAL_EVENTS_MAX))
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for EVENT_NAME\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -1070,18 +1070,18 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                    RtlInitAnsiString( &ansiStr, EventNameBuf1);
                    RtlAnsiStringToUnicodeString(&unicodeStr, &ansiStr, TRUE);
                    pAdapter->NamedEvents[pAdapter->NamedEventsIndex] = IoCreateNotificationEvent(&unicodeStr, &(pAdapter->NamedEventsHandle[pAdapter->NamedEventsIndex]));
-                   if (pAdapter->NamedEvents[pAdapter->NamedEventsIndex] != NULL) 
-                   { 
+                   if (pAdapter->NamedEvents[pAdapter->NamedEventsIndex] != NULL)
+                   {
                       // Take a reference out on the object so that it does not go away if the application
                       //  goes away unexpectedly
                       ObReferenceObject(pAdapter->NamedEvents[pAdapter->NamedEventsIndex]);
-                   
+
                       (*(ULONGLONG *)buffer) = (ULONGLONG)pAdapter->NamedEventsHandle[pAdapter->NamedEventsIndex];
                       Irp->IoStatus.Information = sizeof(ULONGLONG);
                       status = STATUS_SUCCESS;
                       pAdapter->NamedEventsIndex++;
-                   } 
-                   else 
+                   }
+                   else
                    {
                       status = STATUS_UNSUCCESSFUL;
                    }
@@ -1089,14 +1089,14 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 }
                 break;
              }
-             
+
              case IOCTL_QCDEV_DEVICE_REMOVE_EVENTW:
              {
                 if ((buffer == NULL) || (inlen == 0) || (outlen == 0) || (outlen < sizeof(ULONGLONG)) || (pAdapter->NamedEventsIndex >= DEVICE_REMOVAL_EVENTS_MAX))
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for EVENT_NAME\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -1113,8 +1113,8 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                    swprintf(EventNameBuf1, L"\\BaseNamedObjects\\%s", EventNameBuf);
                    RtlInitUnicodeString( &unicodeStr, EventNameBuf1);
                    pAdapter->NamedEvents[pAdapter->NamedEventsIndex] = IoCreateNotificationEvent(&unicodeStr, &(pAdapter->NamedEventsHandle[pAdapter->NamedEventsIndex]));
-                   if (pAdapter->NamedEvents[pAdapter->NamedEventsIndex] != NULL) 
-                   { 
+                   if (pAdapter->NamedEvents[pAdapter->NamedEventsIndex] != NULL)
+                   {
                       // Take a reference out on the object so that it does not go away if the application
                       //  goes away unexpectedly
                       ObReferenceObject(pAdapter->NamedEvents[pAdapter->NamedEventsIndex]);
@@ -1123,22 +1123,22 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                       Irp->IoStatus.Information = sizeof(ULONGLONG);
                       status = STATUS_SUCCESS;
                       pAdapter->NamedEventsIndex++;
-                   } 
-                   else 
+                   }
+                   else
                    {
                       status = STATUS_UNSUCCESSFUL;
                    }
                 }
                 break;
              }
-             
+
              case IOCTL_QCDEV_DEVICE_EVENT_CLOSE:
              {
                 if ((buffer == NULL) || (inlen == 0) || (inlen < sizeof(ULONGLONG)))
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for EVENT_NAME\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -1153,7 +1153,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                       if (pAdapter->NamedEvents[Count] != NULL && ((*(ULONGLONG *)buffer) == (ULONGLONG)pAdapter->NamedEventsHandle[Count]))
                       {
                          _closeHandleG(pAdapter->PortName, pAdapter->NamedEventsHandle[Count], "MPHALT");
-                         
+
                          // Release our reference
                          ObDereferenceObject(pAdapter->NamedEvents[Count]);
                          pAdapter->NamedEvents[Count] = NULL;
@@ -1179,14 +1179,14 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 }
                 break;
              }
-             
+
 #ifdef QCUSB_MUX_PROTOCOL
 
              case IOCTL_QCDEV_RESUME_DL:
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_RESUME_DL\n", pAdapter->PortName)
                 );
                 if (pAdapter->DLPauseEnabled == TRUE)
@@ -1204,7 +1204,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_RESUME_QMAP_DL\n", pAdapter->PortName)
                 );
                 KeSetEvent(&pAdapter->MPThreadQMAPDLResumeEvent, IO_NO_INCREMENT, FALSE);
@@ -1215,7 +1215,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_PAUSE_QMAP_DL\n", pAdapter->PortName)
                 );
                 KeSetEvent(&pAdapter->MPThreadQMAPDLPauseEvent, IO_NO_INCREMENT, FALSE);
@@ -1227,21 +1227,21 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
             {
                QCNET_DbgPrint
                (
-                  MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                  MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                   ("<%s> MPIOC: IOCTL_QCDEV_INJECT_PACKET\n", pAdapter->PortName)
                );
-               
+
                if ( (buffer == NULL) || (inlen == 0) )
                {
                   QCNET_DbgPrint
                   (
-                     MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                     MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                      ("<%s> MPIOC: insufficient input for IOCTL_QCDEV_INJECT_PACKET\n", pAdapter->PortName)
                   );
                   status = STATUS_UNSUCCESSFUL;
                   break;
                }
-               
+
                USBIF_InjectPacket(pAdapter->USBDo, buffer, inlen);
                status = STATUS_SUCCESS;
                break;
@@ -1255,19 +1255,19 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                       ("<%s> MPIOC: IOCTL_QCDEV_MEDIA_CONNECT\n", pAdapter->PortName)
                    );
 
                    pAdapter->IPv4DataCall = 1;
                    pAdapter->IPv6DataCall = 1;
                    pAdapter->IPSettings.IPV4.Address = 0xAB30A8C0; // IP-192.168.48.171 - endianess
-                   
+
                    if ( (buffer == NULL) || (inlen < sizeof( ULONG )) )
                    {
                       QCNET_DbgPrint
                       (
-                         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                          ("<%s> MPIOC: insufficient input for IOCTL_QCDEV_MEDIA_CONNECT\n", pAdapter->PortName)
                       );
                    }
@@ -1279,9 +1279,9 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                          pAdapter->IPSettings.IPV4.Address = IpAddress;
                       }
                    }
-                   
+
                    pAdapter->IPSettings.IPV4.Flags = 1;
-                   pAdapter->IPSettings.IPV6.Flags = 1;                   
+                   pAdapter->IPSettings.IPV6.Flags = 1;
                    KeSetEvent(&pAdapter->MPThreadMediaConnectEvent, IO_NO_INCREMENT, FALSE);
                    // KeSetEvent(&pAdapter->MPThreadMediaConnectEventIPv6, IO_NO_INCREMENT, FALSE);
                 }
@@ -1295,7 +1295,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                       ("<%s> MPIOC: IOCTL_QCDEV_MEDIA_DISCONNECT\n", pAdapter->PortName)
                    );
 
@@ -1303,11 +1303,11 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                    pAdapter->IPv6DataCall = 0;
                    pAdapter->IPSettings.IPV4.Address = 0;
                    pAdapter->IPSettings.IPV4.Flags = 0;
-                   pAdapter->IPSettings.IPV6.Flags = 0;                   
-                
+                   pAdapter->IPSettings.IPV6.Flags = 0;
+
                    pAdapter->ulMediaConnectStatus = NdisMediaStateDisconnected;
                    MPMAIN_MediaDisconnect(pAdapter, TRUE);
-                
+
                    MPMAIN_ResetPacketCount(pAdapter);
                    if ( TRUE == DisconnectedAllAdapters(pAdapter, &returnAdapter))
                    {
@@ -1317,14 +1317,14 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 }
                 break;
              }
-#endif      
+#endif
              case IOCTL_QCDEV_DEVICE_GROUP_INDETIFIER:
              {
                 if ((buffer == NULL) || (outlen == 0) || (outlen < sizeof(ULONGLONG)))
                 {
                    QCNET_DbgPrint
                    (
-                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR, 
+                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                       ("<%s> MPIOC: insufficient input for IOCTL_QCDEV_DEVICE_GROUP_INDETIFIER\n", pAdapter->PortName)
                    );
                    status = STATUS_UNSUCCESSFUL;
@@ -1342,7 +1342,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_QMI_READY (Init/Working) -- %d/%d\n", pAdapter->PortName, pAdapter->QmiInitialized, pAdapter->IsQmiWorking)
                 );
 
@@ -1362,7 +1362,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_GET_PEER_DEV_NAME\n", pAdapter->PortName)
                 );
                 status = MPIOC_GetPeerDeviceName(pAdapter, Irp, outlen);
@@ -1373,7 +1373,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_GET_PRIMARY_ADAPTER_NAME\n", pAdapter->PortName)
                 );
                 status = MPIOC_GetPrimaryAdapterName(pAdapter, Irp, outlen);
@@ -1384,7 +1384,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IOCTL_QCDEV_GET_QMI_QUEUE_SIZE\n", pAdapter->PortName)
                 );
                 if ((buffer == NULL) || (outlen == 0) || (outlen < sizeof(LONG)))
@@ -1437,7 +1437,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 PDEVICE_EXTENSION    pDevExt;
                 PCHAR p;
 
-                pDevExt = (PDEVICE_EXTENSION)pAdapter->USBDo->DeviceExtension;                
+                pDevExt = (PDEVICE_EXTENSION)pAdapter->USBDo->DeviceExtension;
                 p = (PCHAR)buffer;
 
                 if ((buffer == NULL) || (inlen < sizeof(LONG)))
@@ -1525,14 +1525,14 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
              {
                 QCNET_DbgPrint
                 (
-                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                    ("<%s> MPIOC: IRP_MJ_DEVICE_CONTROL/UNKNOWN to 0x%p\n", pAdapter->PortName, DeviceObject)
                 );
                 status = STATUS_UNSUCCESSFUL;
                 break;
              }
           }
-          break;  
+          break;
        }
 
        default:
@@ -1546,7 +1546,7 @@ NTSTATUS MPIOC_IRPDispatch(PDEVICE_OBJECT DeviceObject, PIRP Irp)
       {
          InterlockedDecrement(&(pIocDev->IrpCount));
       }
-      
+
       QCNET_DbgPrint
       (
          MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
@@ -1564,12 +1564,12 @@ MPIOC_Dispatch_Done:
       InterlockedDecrement(&(pIocDev->DeviceOpenCount));
    }
 
-#if 0   
+#if 0
    if (pIocDev->DeviceOpenCount == 0) // client is closed
    {
       KeSetEvent(&pIocDev->ClientClosedEvent, IO_NO_INCREMENT, FALSE);
    }
-#endif   
+#endif
    NdisReleaseSpinLock(MP_CtlLock);
 
    return status;
@@ -1643,7 +1643,7 @@ NDIS_STATUS MPIOC_AddDevice
    {
       RtlCopyMemory(&pIocDev->FilterDeviceInfo, (PFILTER_DEVICE_INFO)ControlDeviceObject, sizeof(FILTER_DEVICE_INFO));
    }
-   
+
    pIocDev->ClientIdV6 = 0;
    pIocDev->ClientId  = 0;
    pIocDev->QMIType   = 0;
@@ -1881,16 +1881,16 @@ NDIS_STATUS MPIOC_CleanupIOCDeviceList(
                       MPIOC_DEV_INFO,
                       List
                    );
-         
+
             /* need to check if this is needed or not: TODO MURALI */
             // terminate the write thread - double check
             MPIOC_CancelWriteThread(pIocDev);
             QCNET_DbgPrint
             (
-               MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+               MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
                ("<%s> MPIOC_CleanupIOCDeviceList 0x%p: wait for close\n", pAdapter->PortName, pIocDev->ControlDeviceObject)
             );
-#if 0            
+#if 0
             KeWaitForSingleObject
             (
                &pIocDev->ClientClosedEvent,
@@ -1913,11 +1913,11 @@ NDIS_STATUS MPIOC_CleanupIOCDeviceList(
                {
                pFilterDeviceInfo = &(pIocDev->FilterDeviceInfo);
                if ((pIocDev->Type == MP_DEV_TYPE_CONTROL) &&
-              	(pIocDev->QMIType == 0) && 
+              	(pIocDev->QMIType == 0) &&
               	(pIocDev->ClientId == 0))
                {
                  // Register the device here
-                 MP_USBSendCustomCommand( pAdapter, IOCTL_QCDEV_CLOSE_CTL_FILE, 
+                 MP_USBSendCustomCommand( pAdapter, IOCTL_QCDEV_CLOSE_CTL_FILE,
               							pFilterDeviceInfo, sizeof(FILTER_DEVICE_INFO), &ReturnBufferLength);
                  MPMAIN_Wait(-(5 * 1000 * 1000)); // +500ms delay here.
                  RtlFreeUnicodeString(&(pIocDev->SymbolicName));
@@ -1947,7 +1947,7 @@ NDIS_STATUS MPIOC_CleanupIOCDeviceList(
             }
 		   peekEntry = nextEntry;
 		   nextEntry = nextEntry->Flink;
-         
+
             ExFreePool(pIocDev);
 	   	}
     }
@@ -1991,7 +1991,7 @@ NDIS_STATUS MPIOC_DeleteDevice
                       MPIOC_DEV_INFO,
                       List
                    );
-         
+
          if ((pIocDev->Adapter == pAdapter) &&
              ((IocDevice == pIocDev)                                ||
               ((ControlDeviceObject == NULL) && (IocDevice == NULL))) )
@@ -2013,7 +2013,7 @@ NDIS_STATUS MPIOC_DeleteDevice
    NdisReleaseSpinLock(MP_CtlLock);
 
    MPIOC_CleanupIOCDeviceList(pAdapter, &LocalList, FALSE);
-   
+
    QCNET_DbgPrint
    (
       MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
@@ -2060,7 +2060,7 @@ NDIS_STATUS MPIOC_DeleteFilterDevice
                       MPIOC_DEV_INFO,
                       List
                    );
-         
+
          if ((pIocDev->Adapter == pAdapter) &&
              ((IocDevice == pIocDev)                                ||
               ((ControlDeviceObject == NULL) && (IocDevice == NULL))) )
@@ -2082,7 +2082,7 @@ NDIS_STATUS MPIOC_DeleteFilterDevice
    NdisReleaseSpinLock(MP_CtlLock);
 
    MPIOC_CleanupIOCDeviceList(pAdapter, &LocalList, TRUE);
-   
+
    QCNET_DbgPrint
    (
       MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
@@ -2168,7 +2168,7 @@ NDIS_STATUS MPIOC_RegisterAllDevices
       }
 
       while (status != NDIS_STATUS_SUCCESS)
-      { 
+      {
          ++myDeviceIndex;
          RtlZeroMemory(myDeviceName, 1024);
 
@@ -2179,7 +2179,7 @@ NDIS_STATUS MPIOC_RegisterAllDevices
 
 
          // Device Name
-         
+
          RtlInitAnsiString(&tmpAnsiString, myDeviceName);
          RtlAnsiStringToUnicodeString(&tmpUnicodeString, &tmpAnsiString, TRUE);
          RtlCopyUnicodeString(OUT &ucDeviceName,IN &tmpUnicodeString);
@@ -2251,7 +2251,7 @@ NDIS_STATUS MPIOC_RegisterAllDevices
                 ControlDeviceObject, ControlDeviceObject->Flags, myDeviceName)
             );
          }
-      }  // while 
+      }  // while
 
       if (status == NDIS_STATUS_SUCCESS)
       {
@@ -2302,13 +2302,13 @@ NDIS_STATUS MPIOC_RegisterAllDevices
                                &configurationHandle
                             );
             }
-            #else            
+            #else
             NdisOpenConfiguration
             (
                &ndisStatus,
                &configurationHandle,
                WrapperConfigurationContext
-            );            
+            );
             #endif // NDIS60_MINIPORT
             if (ndisStatus != NDIS_STATUS_SUCCESS)
             {
@@ -2445,7 +2445,7 @@ NDIS_STATUS MPIOC_RegisterFilterDevice
    }
 
    while (status != NDIS_STATUS_SUCCESS)
-   { 
+   {
       ++myDeviceIndex;
       RtlZeroMemory(myDeviceName, 1024);
 
@@ -2471,9 +2471,9 @@ NDIS_STATUS MPIOC_RegisterFilterDevice
       FilterDeviceInfo.pDeviceName = &ucDeviceName;
       FilterDeviceInfo.pDeviceLinkName = &ucLinkName;
       FilterDeviceInfo.MajorFunctions = &DispatchTable[0];
-         
+
       // Register the device here
-      status = MP_USBSendCustomCommand( pAdapter, IOCTL_QCDEV_CREATE_CTL_FILE, 
+      status = MP_USBSendCustomCommand( pAdapter, IOCTL_QCDEV_CREATE_CTL_FILE,
                                         &FilterDeviceInfo, sizeof(FILTER_DEVICE_INFO), &ReturnBufferLength);
 
       if (status != NDIS_STATUS_SUCCESS)
@@ -2493,7 +2493,7 @@ NDIS_STATUS MPIOC_RegisterFilterDevice
             );
          }
       }
-   }  // while 
+   }  // while
 
    if (status == NDIS_STATUS_SUCCESS && ReturnBufferLength > 0)
    {
@@ -2536,13 +2536,13 @@ NDIS_STATUS MPIOC_RegisterFilterDevice
                             &configurationHandle
                          );
          }
-         #else            
+         #else
          NdisOpenConfiguration
          (
             &ndisStatus,
             &configurationHandle,
             WrapperConfigurationContext
-         );            
+         );
          #endif // NDIS60_MINIPORT
          if (ndisStatus != NDIS_STATUS_SUCCESS)
          {
@@ -2631,8 +2631,8 @@ BOOLEAN QCIOC_IsCorrectQMIRequest
    {
       return isQMI;
    }
-   
-   if (QMIType != 0) 
+
+   if (QMIType != 0)
    {
       if (QMIType == IocDevice->QMIType)
       {
@@ -2685,7 +2685,7 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
    {
       headOfList = &MP_DeviceList;
       peekEntry = headOfList->Flink;
- 
+
       while ((peekEntry != headOfList) && (foundDO == NULL))
       {
          pIocDev = CONTAINING_RECORD
@@ -2697,7 +2697,7 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
 
          if (DeviceObject != NULL)
          {
-            
+
             if (pIocDev->FilterDeviceInfo.pControlDeviceObject == DeviceObject)
             {
                if (QCIOC_IsCorrectQMIRequest(pIocDev, Irp, QMIType) == TRUE)
@@ -2708,7 +2708,7 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
          }
          else
          {
-#if 0         
+#if 0
             if ((pIocDev->Adapter == NULL) ||
                 (pIocDev->Adapter->UsbRemoved == TRUE) ||
                 (pIocDev->Adapter->USBDo == NULL))
@@ -2716,7 +2716,7 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
                peekEntry = peekEntry->Flink;
                continue;
             }
-#endif            
+#endif
 
             pDevExt1 = pIocDev->Adapter->USBDo->DeviceExtension;
             if (pAdapter != NULL)
@@ -2726,7 +2726,7 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
             if (IocDevice == NULL) // find the first match
             {
                // TODO: ADD MORE LOGIC to check the correct adapter list
-               // Search the primary adapter's secondary adapter list and then IoDev of 
+               // Search the primary adapter's secondary adapter list and then IoDev of
                // each seconday adapter list
                if ((pIocDev->QMIType == pQMI->QMIType)
                    &&
@@ -2779,7 +2779,7 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
                {
                   // for broadcast, we only compare QMI type
                   // TODO: ADD MORE LOGIC to check the correct adapter list
-                  // Search the primary adapter's secondary adapter list and then IoDev of 
+                  // Search the primary adapter's secondary adapter list and then IoDev of
                   // each seconday adapter list
                   if ((pIocDev->QMIType == pQMI->QMIType)
                       &&
@@ -2818,13 +2818,13 @@ VOID MPIOC_CancelGetServiceFileIrpRoutine
    ULONG           QMIType = 0;
    PIO_STACK_LOCATION irpStack;
    ANSI_STRING        ansiString;
-   
+
    irpStack = IoGetCurrentIrpStackLocation(pIrp);
 
    IoReleaseCancelSpinLock(pIrp->CancelIrql);
-   
+
    fileObj = irpStack->FileObject;
-   
+
    if (fileObj->FileName.Length != 0)
    {
       RtlUnicodeStringToAnsiString(&ansiString, &(fileObj->FileName), TRUE);
@@ -2836,7 +2836,7 @@ VOID MPIOC_CancelGetServiceFileIrpRoutine
       }
       RtlFreeAnsiString(&ansiString);
    }
-   
+
    pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, pIrp, QMIType);
    if (pIocDev == NULL)
    {
@@ -2887,11 +2887,11 @@ NTSTATUS MPIOC_Read
    ULONG           QMIType = 0;
    PIO_STACK_LOCATION  irpStack;
    ANSI_STRING        ansiString;
-   
+
    irpStack = IoGetCurrentIrpStackLocation(Irp);
-   
+
    fileObj = irpStack->FileObject;
-   
+
    if (fileObj->FileName.Length != 0)
    {
       RtlUnicodeStringToAnsiString(&ansiString, &(fileObj->FileName), TRUE);
@@ -2906,7 +2906,7 @@ NTSTATUS MPIOC_Read
       }
       RtlFreeAnsiString(&ansiString);
    }
-   
+
    pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, Irp, QMIType);
    if (pIocDev == NULL)
    {
@@ -3083,7 +3083,7 @@ NTSTATUS MPIOC_Read
          ("<%s> RIRP Cd 0x%p(0x%x)\n", pAdapter->PortName, Irp, nts)
       );
       InterlockedDecrement(&(pIocDev->IrpCount));
-      
+
       IoCompleteRequest(Irp, IO_NO_INCREMENT);
    }
 
@@ -3102,13 +3102,13 @@ VOID MPIOC_CancelReadRoutine
    ULONG           QMIType = 0;
    PIO_STACK_LOCATION  irpStack;
    ANSI_STRING        ansiString;
-   
+
    irpStack = IoGetCurrentIrpStackLocation(pIrp);
 
    IoReleaseCancelSpinLock(pIrp->CancelIrql);
 
    fileObj = irpStack->FileObject;
-   
+
    if (fileObj->FileName.Length != 0)
    {
       RtlUnicodeStringToAnsiString(&ansiString, &(fileObj->FileName), TRUE);
@@ -3120,7 +3120,7 @@ VOID MPIOC_CancelReadRoutine
       }
       RtlFreeAnsiString(&ansiString);
    }
-   
+
    pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, pIrp, QMIType);
    if (pIocDev == NULL)
    {
@@ -3137,7 +3137,7 @@ VOID MPIOC_CancelReadRoutine
    );
 
    NdisAcquireSpinLock(&pIocDev->IoLock);
-   
+
    if (MPIOC_IsIrpInQueue(pIocDev, pIrp, 0) == TRUE)
    {
       RemoveEntryList(&pIrp->Tail.Overlay.ListEntry);
@@ -3188,11 +3188,11 @@ NTSTATUS MPIOC_Write
    ULONG           QMIType = 0;
    PIO_STACK_LOCATION  irpStack;
    ANSI_STRING        ansiString;
-   
+
    irpStack = IoGetCurrentIrpStackLocation(Irp);
-   
+
    fileObj = irpStack->FileObject;
-   
+
    if (fileObj->FileName.Length != 0)
    {
       RtlUnicodeStringToAnsiString(&ansiString, &(fileObj->FileName), TRUE);
@@ -3207,7 +3207,7 @@ NTSTATUS MPIOC_Write
       }
       RtlFreeAnsiString(&ansiString);
    }
-   
+
    pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, Irp, QMIType);
    if (pIocDev == NULL)
    {
@@ -3261,7 +3261,7 @@ NTSTATUS MPIOC_Write
          ("WIRP Cs 0x%p -zero byte\n", Irp)
       );
       Irp->IoStatus.Information = 0;
-      Irp->IoStatus.Status = STATUS_SUCCESS; 
+      Irp->IoStatus.Status = STATUS_SUCCESS;
       IoCompleteRequest(Irp, IO_NO_INCREMENT);
       return STATUS_SUCCESS;
    }
@@ -3333,7 +3333,7 @@ NTSTATUS MPIOC_Write
       QCNET_DbgPrint
       (
          MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
-         ("<%s> WIRP Cu 0x%p -wrong QMI type or data too short %dB\n", 
+         ("<%s> WIRP Cu 0x%p -wrong QMI type or data too short %dB\n",
            pAdapter->PortName, Irp, inlen)
       );
       Irp->IoStatus.Information = 0;
@@ -3410,7 +3410,7 @@ void MPIOC_WriteThread
 
    QCNET_DbgPrint
    (
-      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
       ("<%s> ---> MPIOC_WriteThread\n", pAdapter->PortName)
    );
 
@@ -3425,7 +3425,7 @@ void MPIOC_WriteThread
       MPIOC_EmptyIrpCompletionQueue(pIocDev);
       QCNET_DbgPrint
       (
-         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
          ("<%s> MPIOC Wth: out of memory.\n", pAdapter->PortName)
       );
       return;
@@ -3442,7 +3442,7 @@ void MPIOC_WriteThread
       MPIOC_EmptyIrpCompletionQueue(pIocDev);
       QCNET_DbgPrint
       (
-         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
          ("<%s> MPIOC Wth: out of memory-IRP.\n", pAdapter->PortName)
       );
       ExFreePool(pwbArray);
@@ -3454,7 +3454,7 @@ void MPIOC_WriteThread
    {
       QCNET_DbgPrint
       (
-         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+         MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
          ("<%s> MPIOC Wth: rm lock err\n", pAdapter->PortName)
       );
       ExFreePool(pwbArray);
@@ -3541,7 +3541,7 @@ void MPIOC_WriteThread
                QCNET_DbgPrint
                (
                   MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
-                  ("<%s> Wth SYSB IRP 0x%p 0x%p(%uB)\n", 
+                  ("<%s> Wth SYSB IRP 0x%p 0x%p(%uB)\n",
                     pAdapter->PortName, pIocDev->pWriteCurrent, pActiveBuffer, ulReqBytes)
                );
             }
@@ -3601,7 +3601,7 @@ void MPIOC_WriteThread
                         FALSE
                      );
                   }
-   
+
                   pIocDev->pWriteCurrent = NULL;
                   qmiBufferLength = 0;
 
@@ -3610,15 +3610,15 @@ void MPIOC_WriteThread
                      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_ERROR,
                      ("<%s> IocWth: NO_MEM for QMI", pAdapter->PortName)
                   );
-   
+
                   NdisReleaseSpinLock(&pIocDev->IoLock);
 
                   continue;  // back to the loop
                }  // if (qmiBuffer == NULL)
-   
+
                // QMI message length including the USB IF type
-               qmiBufferLength = ulReqBytes+sizeof(QCQMI); 
-   
+               qmiBufferLength = ulReqBytes+sizeof(QCQMI);
+
                NdisReleaseSpinLock(&pIocDev->IoLock);
             }
          }  // if (pActiveBuffer == NULL)
@@ -3733,7 +3733,7 @@ void MPIOC_WriteThread
             ntStatus = STATUS_UNSUCCESSFUL;
             pIrp->IoStatus.Status = ntStatus;
             MPIOC_WtIrpCompletion(pAdapter->USBDo, pIrp, pIocDev);
-            
+
          }
          if(ntStatus != STATUS_PENDING)
          {
@@ -4258,13 +4258,13 @@ VOID MPIOC_CancelWriteRoutine
    ULONG           QMIType = 0;
    PIO_STACK_LOCATION  irpStack;
    ANSI_STRING        ansiString;
-   
+
    irpStack = IoGetCurrentIrpStackLocation(pIrp);
 
    IoReleaseCancelSpinLock(pIrp->CancelIrql);
 
    fileObj = irpStack->FileObject;
-   
+
    if (fileObj->FileName.Length != 0)
    {
       RtlUnicodeStringToAnsiString(&ansiString, &(fileObj->FileName), TRUE);
@@ -4276,7 +4276,7 @@ VOID MPIOC_CancelWriteRoutine
       }
       RtlFreeAnsiString(&ansiString);
    }
-   
+
    pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, pIrp, QMIType);
    if (pIocDev == NULL)
    {
@@ -4336,7 +4336,7 @@ NTSTATUS MPIOC_StartWriteThread(PMPIOC_DEV_INFO pIocDev)
    PMP_ADAPTER       pAdapter = pIocDev->Adapter;
    NTSTATUS          ntStatus = STATUS_SUCCESS;
    KIRQL             irql     = KeGetCurrentIrql();
-   OBJECT_ATTRIBUTES objAttr; 
+   OBJECT_ATTRIBUTES objAttr;
 
    // Make sure the write thread is created with IRQL==PASSIVE_LEVEL
    NdisAcquireSpinLock(&pIocDev->IoLock);
@@ -4374,7 +4374,7 @@ NTSTATUS MPIOC_StartWriteThread(PMPIOC_DEV_INFO pIocDev)
          );
          return STATUS_SUCCESS;
       }
- 
+
       KeClearEvent(&pIocDev->WriteThreadStartedEvent);
       InitializeObjectAttributes(&objAttr, NULL, OBJ_KERNEL_HANDLE, NULL, NULL);
       ntStatus = PsCreateSystemThread
@@ -4452,7 +4452,7 @@ NTSTATUS MPIOC_StartWriteThread(PMPIOC_DEV_INFO pIocDev)
       MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
       ("<%s> MPIOC_WT alive-%d    irql-0x%x\n", pAdapter->PortName, ntStatus, irql)
    );
-  
+
    return ntStatus;
 }  // MPIOC_StartWriteThread
 
@@ -4584,7 +4584,7 @@ VOID MPIOC_CleanupQueues(PMPIOC_DEV_INFO pIocDev, UCHAR cookie)
 
    QCNET_DbgPrint
    (
-      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
       ("<%s> ---> MPIOC_CleanupQueues (%d)\n", pAdapter->PortName, cookie));
 
    MPIOC_PurgeQueue(pIocDev, &pIocDev->ReadIrpQueue, &pIocDev->IoLock, 1);
@@ -4610,7 +4610,7 @@ VOID MPIOC_CleanupQueues(PMPIOC_DEV_INFO pIocDev, UCHAR cookie)
 
    QCNET_DbgPrint
    (
-      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL, 
+      MP_DBG_MASK_CONTROL, MP_DBG_LEVEL_DETAIL,
       ("<%s> <--- MPIOC_CleanupQueues (%d)\n", pAdapter->PortName, cookie)
    );
 }  // MPIOC_CleanupQueues
@@ -4651,7 +4651,7 @@ VOID MPIOC_SetStopState
                pIocDev->MPStopped = TRUE;
                if (TerminateAll == TRUE)
                {
-#if 0               
+#if 0
                   // Release client ID for TYPE_CLIENT?????
                   // if (pAdapter->Flags & fMP_ADAPTER_SURPRISE_REMOVED)
                   {
@@ -4743,7 +4743,7 @@ NTSTATUS MPIOC_CacheNotificationIrp
    NTSTATUS           ntStatus;
    PIO_STACK_LOCATION irpStack;
    PMP_ADAPTER        pAdapter = pIocDev->Adapter;
-   
+
    pIrp->IoStatus.Information = 0;
    ntStatus = STATUS_INVALID_PARAMETER;
 
@@ -4903,7 +4903,7 @@ VOID MPIOC_CancelNotificationRoutine(PDEVICE_OBJECT DeviceObject, PIRP pIrp)
       }
       RtlFreeAnsiString(&ansiString);
    }
-   
+
    pIocDev = MPIOC_FindIoDevice(NULL, DeviceObject, NULL, NULL, pIrp, QMIType);
    if (pIocDev == NULL)
    {
@@ -5488,8 +5488,8 @@ NTSTATUS MPIOC_GetPeerDeviceName(PMP_ADAPTER pAdapter, PIRP Irp, ULONG BufLen)
    IoSetCompletionRoutine
    (
       pIrp,
-      (PIO_COMPLETION_ROUTINE)MPIOC_GetPeerDeviceNameCompletion,
-      (PVOID)pAdapter,
+      MPIOC_GetPeerDeviceNameCompletion,
+      pAdapter,
       TRUE,TRUE,TRUE
    );
 

--- a/src/windows/ndis/MPIOC.h
+++ b/src/windows/ndis/MPIOC.h
@@ -316,7 +316,7 @@ BOOLEAN MPIOC_LocalProcessing(PIRP Irp);
 
 #ifndef SECURITY_DESCRIPTOR_CONTROL
 typedef USHORT SECURITY_DESCRIPTOR_CONTROL, *PSECURITY_DESCRIPTOR_CONTROL;
-#endif 
+#endif
 
 #ifndef SECURITY_DESCRIPTOR
 typedef struct _SECURITY_DESCRIPTOR
@@ -337,12 +337,7 @@ NDIS_STATUS MPIOC_ResetDeviceSecurity
     PUNICODE_STRING DeviceLinkName
 );
 
-NTSTATUS MPIOC_GetPeerDeviceNameCompletion
-(
-    PDEVICE_OBJECT pDO,
-    PIRP           pIrp,
-    PVOID          pContext
-);
+IO_COMPLETION_ROUTINE MPIOC_GetPeerDeviceNameCompletion;
 
 NTSTATUS MPIOC_GetPeerDeviceName(PMP_ADAPTER pAdapter, PIRP Irp, ULONG BufLen);
 

--- a/src/windows/ndis/MPQCTL.c
+++ b/src/windows/ndis/MPQCTL.c
@@ -19,7 +19,7 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "MPQCTL.tmh"
 
 #endif   // EVENT_TRACING
@@ -830,7 +830,7 @@ NDIS_STATUS MPQCTL_SetDataFormat
     }
 
 #endif // MP_QCQOS_ENABLED
-#endif 
+#endif
 
     QCNET_DbgPrint
     (
@@ -1262,8 +1262,8 @@ NDIS_STATUS MPQCTL_SendQMICTLRequest
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MPQCTL_SendIRPCompletion,
-        (PVOID)pAdapter, // Context,
+        MPQCTL_SendIRPCompletion,
+        pAdapter, // Context,
         TRUE, TRUE, TRUE
     );
 
@@ -1543,7 +1543,7 @@ VOID MPQCTL_HandleGetVersionRsp
                         preamble->LabelLength
                     );
 
-                    pAddendumVer += sizeof(UCHAR); //label length field 
+                    pAddendumVer += sizeof(UCHAR); //label length field
                     pAddendumVer += preamble->LabelLength; // skip the label
                     numInstances = *((PUCHAR)pAddendumVer);
                     pAddendumVer += sizeof(UCHAR); // advance to the version section
@@ -1642,7 +1642,7 @@ VOID MPQCTL_HandleGetVersionRsp
         pAdapter->MPEnableQMAPV2 = 0;
         pAdapter->MPEnableQMAPV3 = 0;
 #endif
-#endif      
+#endif
     }
     if ((pAdapter->QMUXVersion[QMUX_TYPE_WDS_ADMIN].Major >= 1) &&
         (pAdapter->QMUXVersion[QMUX_TYPE_WDS_ADMIN].Minor >= 19))
@@ -2045,7 +2045,7 @@ PVOID MPQCTL_HandleSetDataFormatReq
     {
         *MsgLen += sizeof(QMICTL_SET_DATA_FORMAT_TLV_LINK_PROT);
     }
-#endif // QC_IP_MODE      
+#endif // QC_IP_MODE
 
 #ifdef QCMP_UL_TLP
     if (pAdapter->MPEnableTLP != 0) // registry setting

--- a/src/windows/ndis/MPQCTL.h
+++ b/src/windows/ndis/MPQCTL.h
@@ -109,7 +109,7 @@ typedef struct _QMICTL_SET_INSTANCE_ID_RESP_MSG
     UCHAR  TLV2Type;        // QCTLV_TYPE_REQUIRED_PARAMETER
     USHORT TLV2Length;      // 0x0002
     USHORT QMI_ID;          // Upper byte is assigned by MSM,
-                            // lower assigned by host 
+                            // lower assigned by host
 } QMICTL_SET_INSTANCE_ID_RESP_MSG, *PQMICTL_SET_INSTANCE_ID_RESP_MSG;
 
 typedef struct _QMICTL_GET_VERSION_REQ_MSG
@@ -384,12 +384,7 @@ NDIS_STATUS MPQCTL_Request
     PVOID       Context
 );
 
-NTSTATUS MPQCTL_SendIRPCompletion
-(
-    PDEVICE_OBJECT pDO,
-    PIRP           pIrp,
-    PVOID          pContext
-);
+IO_COMPLETION_ROUTINE MPQCTL_SendIRPCompletion;
 
 NDIS_STATUS MPQCTL_SendQMICTLRequest
 (
@@ -433,12 +428,6 @@ NDIS_STATUS MPQCTL_SetDataFormat
 (
     PMP_ADAPTER pAdapter,
     PVOID       Context   // Adapter
-);
-
-NDIS_STATUS MPQCTL_CtlSync
-(
-   PMP_ADAPTER pAdapter,
-   PVOID       Context   // Adapter
 );
 
 // ============= Internal Functions ==============
@@ -527,19 +516,6 @@ VOID MPQCTL_HandleSetDataFormatRsp
     PQMICTL_TRANSACTION_ITEM item
 );
 
-PVOID MPQCTL_HandleCtlSyncReq
-(
-   PMP_ADAPTER pAdapter,
-   PUCHAR      TransactionId,
-   PULONG      MsgLen
-);
-
-VOID MPQCTL_HandleCtlSyncRsp
-(
-   PMP_ADAPTER              pAdapter,
-   PQCQMI                   qmi
-);
-
 VOID MPQCTL_HandleRevokeClientIdInd
 (
     PMP_ADAPTER              pAdapter,
@@ -559,24 +535,6 @@ NDIS_STATUS MPQCTL_RemoveOldTransactionItem
 );
 
 #pragma pack(pop)
-NDIS_STATUS MPQCTL_SendQMICTLSync
-(
-    PMP_ADAPTER pAdapter
-);
-
-PVOID MPQCTL_HandleSyncReq
-(
-    PMP_ADAPTER pAdapter,
-    PUCHAR      TransactionId,
-    PULONG      MsgLen
-);
-
-VOID MPQCTL_HandleSyncRsp
-(
-    PMP_ADAPTER              pAdapter,
-    PQCQMI                   qmi,
-    PQMICTL_TRANSACTION_ITEM item
-);
 
 VOID MPQCTL_HandleSyncInd
 (

--- a/src/windows/ndis/MPUsb.c
+++ b/src/windows/ndis/MPUsb.c
@@ -25,13 +25,13 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "MPUsb.tmh"
 
 #endif  // EVENT_TRACING
 
-#undef USE_MDL 
-//#define USE_MDL 
+#undef USE_MDL
+//#define USE_MDL
 
 #ifndef USE_MDL
 
@@ -156,7 +156,7 @@ NTSTATUS MP_TxIRPComplete(PDEVICE_OBJECT pDO, PIRP pIrp, PVOID pContext)
     }
 
 #ifdef USE_MDL
-    // Free the Mdls that were created to 
+    // Free the Mdls that were created to
     // RWD ??? It may be sufficient to free the to Mdl here
     pCurMdl = pIrp->MdlAddress;
 
@@ -695,7 +695,7 @@ NTSTATUS MP_RxIRPCompletion(
 
     if ((!NT_SUCCESS(pIrp->IoStatus.Status)) ||
         (pAdapter->PacketFilter == 0) ||
-        (pAdapter->ToPowerDown == TRUE))  // no filter 
+        (pAdapter->ToPowerDown == TRUE))  // no filter
     {
         // This was not a successful receive so just relink this receive to the free list
         InsertTailList(&pAdapter->RxFreeList, pList);
@@ -792,10 +792,10 @@ NTSTATUS MP_RxIRPCompletion(
                 KeSetEvent(&pAdapter->MPThreadDLPauseEvent, IO_NO_INCREMENT, FALSE);
             }
         }
-#endif // #ifdef QCUSB_MUX_PROTOCOL        
+#endif // #ifdef QCUSB_MUX_PROTOCOL
     }
 #ifdef USE_MDL
-    // Free the Mdls that were created to 
+    // Free the Mdls that were created to
     // RWD ??? It may be sufficient to free the to Mdl here
     pCurMdl = pIrp->MdlAddress;
     while (pCurMdl)
@@ -919,8 +919,8 @@ void MP_USBPostPacketRead(PMP_ADAPTER  pAdapter, PLIST_ENTRY  pList)
 
     IoSetCompletionRoutine(
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MP_RxIRPCompletion,
-        (PVOID)pAdapter,
+        MP_RxIRPCompletion,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
 
@@ -1062,8 +1062,8 @@ void MP_USBPostControlRead
 
     IoSetCompletionRoutine(
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MP_RcIRPCompletion,
-        (PVOID)pAdapter,
+        MP_RcIRPCompletion,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
 
@@ -1233,7 +1233,7 @@ NDIS_STATUS MP_USBRequest
 
     InsertTailList(&pAdapter->OIDWaitingList, pList);
 
-    MPMAIN_ScheduleWorkItem( pAdapter );   
+    MPMAIN_ScheduleWorkItem( pAdapter );
 
     QCNET_DbgPrint
     (
@@ -1294,8 +1294,8 @@ void MP_USBCleanUp(PMP_ADAPTER pAdapter)
 
     IoSetCompletionRoutine(
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MP_CleanUpIRPCompletion,
-        (PVOID)pAdapter,
+        MP_CleanUpIRPCompletion,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
 
@@ -1346,7 +1346,7 @@ NDIS_STATUS MP_USBSendControl
     }
     InterlockedIncrement(&(pAdapter->nBusyWrite));
     NdisReleaseSpinLock(&pAdapter->CtrlWriteLock);
-    MPMAIN_ScheduleWorkItem( pAdapter );   
+    MPMAIN_ScheduleWorkItem( pAdapter );
     return NDIS_STATUS_PENDING;
 }
 
@@ -1425,8 +1425,8 @@ NDIS_STATUS MP_USBSendControlRequest
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MP_SendControlCompletion,
-        (PVOID)pAdapter,
+        MP_SendControlCompletion,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
     returnAdapter = FindStackDeviceObject(pAdapter);
@@ -1550,8 +1550,8 @@ NDIS_STATUS MP_USBSendCustomCommand
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MP_SendCustomCommandCompletion,
-        (PVOID)pAdapter,
+        MP_SendCustomCommandCompletion,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
 
@@ -2059,8 +2059,8 @@ VOID MPUSB_ArpResponse
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MPUSB_LoopbackIRPCompletion,
-        (PVOID)pAdapter,
+        MPUSB_LoopbackIRPCompletion,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
 
@@ -2151,8 +2151,8 @@ VOID MP_USBPostPacketReadEx(PMP_ADAPTER pAdapter, PLIST_ENTRY pList)
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)MP_RxIRPCompletionEx,
-        (PVOID)pAdapter,
+        MP_RxIRPCompletionEx,
+        pAdapter,
         TRUE, TRUE, TRUE
     );
 
@@ -2403,7 +2403,7 @@ NTSTATUS MP_RxIRPCompletionEx(PDEVICE_OBJECT pDO, PIRP pIrp, PVOID pContext)
                 pAdapter->AdapterHandle,
                 nbl,
                 NDIS_DEFAULT_PORT_NUMBER,
-                1,  // NumberOfNetBufferLists 
+                1,  // NumberOfNetBufferLists
                 rxFlags   // flags
             );
 
@@ -4817,16 +4817,16 @@ VOID MPUSB_TLPTxPacket
          NdisAcquireSpinLock(&pAdapter->TxLock);
          InsertHeadList(&pAdapter->UplinkFreeBufferQueue, &tlpItem->List);
          NdisReleaseSpinLock(&pAdapter->TxLock);
-   
+
          // Set the transmit timer
-         SetTransmitTimer(pAdapter);     
-   
+         SetTransmitTimer(pAdapter);
+
          if (pAdapter->MPQuickTx != 0)
          {
             NDIS_SET_PACKET_STATUS(pNdisPacket, NDIS_STATUS_SUCCESS);
             MPUSB_TLPIndicateCompleteTx(pAdapter, pNdisPacket, 1);
          }
-   
+
          goto Tx_Exit;
    }
    else if (( tlpItem->AggregationCount < (MP_NUM_MBIM_UL_DATAGRAM_ITEMS_DEFAULT - 2)) && (pAdapter->MBIMULEnabled == TRUE))
@@ -4869,7 +4869,7 @@ VOID MPUSB_TLPTxPacket
         NdisReleaseSpinLock(&pAdapter->TxLock);
 
        // Set the transmit timer
-       SetTransmitTimer(pAdapter);      
+       SetTransmitTimer(pAdapter);
 
         if (pAdapter->MPQuickTx != 0)
         {
@@ -5128,7 +5128,7 @@ BOOLEAN MPUSB_TLPProcessPendingTxQueue(PMP_ADAPTER pAdapter)
                         List
                     );
 
-#if 0               
+#if 0
                     MPUSB_CompleteNetBufferList
                     (
                         pAdapter,
@@ -5141,13 +5141,13 @@ BOOLEAN MPUSB_TLPProcessPendingTxQueue(PMP_ADAPTER pAdapter)
                     NdisReleaseSpinLock(&pAdapter->TxLock);
                     ((PMPUSB_TX_CONTEXT_NBL)txNb->NBL)->NdisStatus = NDIS_STATUS_FAILURE;
                     MP_TxIRPCompleteEx(pAdapter->USBDo, NULL, txNb, TRUE);
-#else               
+#else
                     PNDIS_PACKET pNdisPacket;
                     pNdisPacket = ListItemToPacket(pList);
                     NDIS_SET_PACKET_STATUS(pNdisPacket, NDIS_STATUS_FAILURE);
                     InsertTailList(&pAdapter->TxCompleteList, pList);
                     NdisReleaseSpinLock(&pAdapter->TxLock);
-#endif               
+#endif
                 }
                 else
                 {
@@ -5199,7 +5199,7 @@ BOOLEAN MPUSB_TLPProcessPendingTxQueue(PMP_ADAPTER pAdapter)
         (pAdapter->TLPEnabled == FALSE) && (pAdapter->MBIMULEnabled == FALSE) &&
         (pAdapter->QMAPEnabledV1 == FALSE)
         && (pAdapter->QMAPEnabledV4 == FALSE)
-#ifdef QCUSB_MUX_PROTOCOL                        
+#ifdef QCUSB_MUX_PROTOCOL
 #if defined(QCMP_QMAP_V2_SUPPORT)
         && (pAdapter->QMAPEnabledV2 == FALSE)
         && (pAdapter->QMAPEnabledV3 == FALSE)
@@ -5313,7 +5313,7 @@ VOID MPUSB_PurgeTLPQueuesEx(PMP_ADAPTER pAdapter, BOOLEAN FreeMemory)
             {
                 headOfList = RemoveHeadList(&tlpItem->PacketList);
                 nbContext = CONTAINING_RECORD(headOfList, MPUSB_TX_CONTEXT_NB, List);
-#if 0            
+#if 0
                 if (nblContext->AbortFlag != 0)
                 {
                     MPUSB_CompleteNetBufferList
@@ -5350,7 +5350,7 @@ VOID MPUSB_PurgeTLPQueuesEx(PMP_ADAPTER pAdapter, BOOLEAN FreeMemory)
         PLIST_ENTRY  pList;
         pList = RemoveHeadList(&pAdapter->TxBusyList);
         nbContext = CONTAINING_RECORD(pList, MPUSB_TX_CONTEXT_NB, List);
-#if 0      
+#if 0
         if (nblContext->AbortFlag != 0)
         {
             MPUSB_CompleteNetBufferList
@@ -5384,7 +5384,7 @@ VOID MPUSB_PurgeTLPQueuesEx(PMP_ADAPTER pAdapter, BOOLEAN FreeMemory)
         PLIST_ENTRY  pList;
         pList = RemoveHeadList(&pAdapter->TxPendingList);
         nbContext = CONTAINING_RECORD(pList, MPUSB_TX_CONTEXT_NB, List);
-#if 0      
+#if 0
         if (nblContext->AbortFlag != 0)
         {
             MPUSB_CompleteNetBufferList
@@ -6128,10 +6128,10 @@ VOID MPUSB_TLPTxPacketEx
     NdisAcquireSpinLock(&pAdapter->TxLock);
     InsertHeadList(&pAdapter->UplinkFreeBufferQueue, &tlpItem->List);
     NdisReleaseSpinLock(&pAdapter->TxLock);
-    
+
     // Set the transmit timer
     SetTransmitTimer(pAdapter);
-    
+
     if (pAdapter->MPQuickTx != 0)
     {
         ((PMPUSB_TX_CONTEXT_NBL)nbContext->NBL)->NdisStatus = NDIS_STATUS_SUCCESS;
@@ -6181,7 +6181,7 @@ VOID MPUSB_TLPTxPacketEx
 
       // Set the transmit timer
       SetTransmitTimer(pAdapter);
-      
+
       if (pAdapter->MPQuickTx != 0)
       {
           ((PMPUSB_TX_CONTEXT_NBL)nbContext->NBL)->NdisStatus = NDIS_STATUS_SUCCESS;
@@ -6194,14 +6194,14 @@ VOID MPUSB_TLPTxPacketEx
       if (pAdapter->MPQuickTx != 0)
       {
          ((PMPUSB_TX_CONTEXT_NBL)nbContext->NBL)->NdisStatus = NDIS_STATUS_SUCCESS;
-         MP_TxIRPCompleteEx(pAdapter->USBDo, NULL, nbContext, TRUE);      
+         MP_TxIRPCompleteEx(pAdapter->USBDo, NULL, nbContext, TRUE);
       }
 
         if ((pAdapter->TLPEnabled == TRUE) ||
             (pAdapter->MBIMULEnabled == TRUE) ||
             (pAdapter->QMAPEnabledV1 == TRUE)
             || (pAdapter->QMAPEnabledV4 == TRUE)
-#ifdef QCUSB_MUX_PROTOCOL                        
+#ifdef QCUSB_MUX_PROTOCOL
 #if defined(QCMP_QMAP_V2_SUPPORT)
             || (pAdapter->QMAPEnabledV2 == TRUE)
             || (pAdapter->QMAPEnabledV3 == TRUE)
@@ -6416,7 +6416,7 @@ NTSTATUS MPUSB_TLPTxIRPCompleteEx
         nPkt++;
         if (NT_SUCCESS(pIrp->IoStatus.Status))
         {
-#if 0      
+#if 0
             MPUSB_CompleteNetBufferList
             (
                 pAdapter,
@@ -6431,7 +6431,7 @@ NTSTATUS MPUSB_TLPTxIRPCompleteEx
         }
         else
         {
-#if 0      
+#if 0
             MPUSB_CompleteNetBufferList
             (
                 pAdapter,
@@ -7054,5 +7054,5 @@ ULONG GetNextTxPacketSize(PMP_ADAPTER pAdapter, PLIST_ENTRY listEntry)
         &dwPacketLength
     );
     return dwPacketLength;
-#endif   
+#endif
 }

--- a/src/windows/ndis/MPUsb.h
+++ b/src/windows/ndis/MPUsb.h
@@ -12,6 +12,19 @@ GENERAL DESCRIPTION
 #ifndef _MPUSB_H
 #define _MPUSB_H
 
+IO_COMPLETION_ROUTINE MP_TxIRPComplete;
+IO_COMPLETION_ROUTINE MP_RxIRPCompletion;
+IO_COMPLETION_ROUTINE MP_RcIRPCompletion;
+IO_COMPLETION_ROUTINE MP_WcIRPCompletion;
+IO_COMPLETION_ROUTINE MP_CleanUpIRPCompletion;
+IO_COMPLETION_ROUTINE MP_SendControlCompletion;
+IO_COMPLETION_ROUTINE MP_SendCustomCommandCompletion;
+IO_COMPLETION_ROUTINE MPUSB_LoopbackIRPCompletion;
+IO_COMPLETION_ROUTINE MP_TxIRPCompleteExStub;
+IO_COMPLETION_ROUTINE MP_RxIRPCompletionEx;
+IO_COMPLETION_ROUTINE MPUSB_TLPTxIRPComplete;
+IO_COMPLETION_ROUTINE MPUSB_TLPTxIRPCompleteEx;
+
 #ifdef QCUSB_MUX_PROTOCOL
 #ifdef QMI_OVER_DATA
 
@@ -72,13 +85,6 @@ NDIS_STATUS MP_USBSendControlRequest
     ULONG       BufferLength
 );
 
-NTSTATUS MP_SendControlCompletion
-(
-    PDEVICE_OBJECT pDO,
-    PIRP           pIrp,
-    PVOID          pContext
-);
-
 NDIS_STATUS MP_USBSendCustomCommand
 (
     PMP_ADAPTER pAdapter,
@@ -86,13 +92,6 @@ NDIS_STATUS MP_USBSendCustomCommand
     PVOID       Buffer,
     ULONG       BufferLength,
     ULONG *pReturnBufferLength
-);
-
-NTSTATUS MP_SendCustomCommandCompletion
-(
-    PDEVICE_OBJECT pDO,
-    PIRP           pIrp,
-    PVOID          pContext
 );
 
 ULONG MPUSB_CopyNdisPacketToBuffer
@@ -128,8 +127,6 @@ VOID MPUSB_ArpResponse
 #ifdef NDIS60_MINIPORT
 
 VOID MP_USBPostPacketReadEx(PMP_ADAPTER pAdapter, PLIST_ENTRY pList);
-
-NTSTATUS MP_RxIRPCompletionEx(PDEVICE_OBJECT pDO, PIRP pIrp, PVOID pContext);
 
 PMPUSB_RX_NBL MPUSB_FindRxRequest(PMP_ADAPTER pAdapter, PIRP Irp);
 
@@ -194,13 +191,6 @@ VOID MPUSB_PurgeTLPQueues(PMP_ADAPTER pAdapter, BOOLEAN FreeMemory);
 
 INT MPUSB_AggregationAvailable(PMP_ADAPTER pAdapter, BOOLEAN UseSpinLock, ULONG SizeofPacket);
 
-NTSTATUS MPUSB_TLPTxIRPComplete
-(
-    PDEVICE_OBJECT pDO,
-    PIRP           pIrp,
-    PVOID          pContext
-);
-
 VOID MPUSB_TLPTxPacket
 (
     PMP_ADAPTER  pAdapter,
@@ -226,13 +216,6 @@ NDIS_STATUS MP_RequestDeviceID
 
 VOID MPUSB_PurgeTLPQueuesEx(PMP_ADAPTER pAdapter, BOOLEAN FreeMemory);
 
-NTSTATUS MPUSB_TLPTxIRPCompleteEx
-(
-    PDEVICE_OBJECT pDO,
-    PIRP           pIrp,
-    PVOID          pContext
-);
-
 VOID MPUSB_TLPTxPacketEx
 (
     PMP_ADAPTER  pAdapter,
@@ -240,8 +223,6 @@ VOID MPUSB_TLPTxPacketEx
     BOOLEAN      IsQosPacket,
     PLIST_ENTRY  pList
 );
-
-BOOLEAN MPUSB_TLPProcessPendingTxQueueEx(PMP_ADAPTER pAdapter);
 
 #endif
 

--- a/src/windows/qdss/QDBDEV.h
+++ b/src/windows/qdss/QDBDEV.h
@@ -16,15 +16,8 @@ GENERAL DESCRIPTION
 #define QDSS_DEBUG_FILE L"\\DEBUG"
 #define QDSS_DPL_FILE   L"\\DPL"
 
-VOID QDBDEV_EvtDeviceFileCreate
-(
-    WDFDEVICE     Device,    // handle to a framework device object
-    WDFREQUEST    Request,   // handle to request object representing file creation req
-    WDFFILEOBJECT FileObject // handle to a framework file obj describing a file
-);
-
-VOID QDBDEV_EvtDeviceFileClose(WDFFILEOBJECT FileObject);
-
-VOID QDBDEV_EvtDeviceFileCleanup(WDFFILEOBJECT FileObject);
+EVT_WDF_DEVICE_FILE_CREATE QDBDEV_EvtDeviceFileCreate;
+EVT_WDF_FILE_CLOSE QDBDEV_EvtDeviceFileClose;
+EVT_WDF_FILE_CLEANUP QDBDEV_EvtDeviceFileCleanup;
 
 #endif // QDBDEV_H

--- a/src/windows/qdss/QDBDSP.c
+++ b/src/windows/qdss/QDBDSP.c
@@ -433,7 +433,7 @@ NTSTATUS QDBDSP_GetParentId
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)QDBDSP_IrpIoCompletion,
+        QDBDSP_IrpIoCompletion,
         (PVOID)pDevContext,
         TRUE, TRUE, TRUE
     );

--- a/src/windows/qdss/QDBDSP.h
+++ b/src/windows/qdss/QDBDSP.h
@@ -14,34 +14,10 @@ GENERAL DESCRIPTION
 #ifndef QDBDSP_H
 #define QDBDSP_H
 
-VOID QDBDSP_IoDeviceControl
-(
-    WDFQUEUE   Queue,
-    WDFREQUEST Request,
-    size_t     OutputBufferLength,
-    size_t     InputBufferLength,
-    ULONG      IoControlCode
-);
-
-VOID QDBDSP_IoStop
-(
-    WDFQUEUE   Queue,
-    WDFREQUEST Request,
-    ULONG      ActionFlags
-);
-
-VOID QDBDSP_IoResume
-(
-    WDFQUEUE   Queue,
-    WDFREQUEST Request
-);
-
-NTSTATUS QDBDSP_IrpIoCompletion
-(
-    PDEVICE_OBJECT DeviceObject,
-    PIRP           Irp,
-    PVOID          Context
-);
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL QDBDSP_IoDeviceControl;
+EVT_WDF_IO_QUEUE_IO_STOP QDBDSP_IoStop;
+EVT_WDF_IO_QUEUE_IO_RESUME QDBDSP_IoResume;
+IO_COMPLETION_ROUTINE QDBDSP_IrpIoCompletion;
 
 NTSTATUS QDBDSP_GetParentId
 (

--- a/src/windows/qdss/QDBPNP.c
+++ b/src/windows/qdss/QDBPNP.c
@@ -2297,8 +2297,8 @@ NTSTATUS QDBPNP_GetParentDeviceName(WDFDEVICE Device)
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)QDBDSP_IrpIoCompletion,
-        (PVOID)pDevContext,
+        QDBDSP_IrpIoCompletion,
+        pDevContext,
         TRUE, TRUE, TRUE
     );
 

--- a/src/windows/qdss/QDBPNP.h
+++ b/src/windows/qdss/QDBPNP.h
@@ -32,24 +32,13 @@ NTSTATUS QDBPNP_SetStamp
     BOOLEAN        Startup
 );
 
-NTSTATUS QDBPNP_EvtDriverDeviceAdd
-(
-    WDFDRIVER        Driver,
-    PWDFDEVICE_INIT  DeviceInit
-);
-
-VOID QDBPNP_EvtDriverCleanupCallback(WDFOBJECT Object);
-
-VOID QDBPNP_EvtDeviceCleanupCallback(WDFOBJECT Object);
+EVT_WDF_DRIVER_DEVICE_ADD QDBPNP_EvtDriverDeviceAdd;
+EVT_WDF_OBJECT_CONTEXT_CLEANUP QDBPNP_EvtDriverCleanupCallback;
+EVT_WDF_OBJECT_CONTEXT_CLEANUP QDBPNP_EvtDeviceCleanupCallback;
 
 VOID QDBPNP_WaitForDrainToStop(PDEVICE_CONTEXT pDevContext);
 
-NTSTATUS QDBPNP_EvtDevicePrepareHW
-(
-    WDFDEVICE    Device,
-    WDFCMRESLIST ResourceList,
-    WDFCMRESLIST ResourceListTranslated
-);
+EVT_WDF_DEVICE_PREPARE_HARDWARE QDBPNP_EvtDevicePrepareHW;
 
 NTSTATUS QDBPNP_EnumerateDevice(IN WDFDEVICE Device);
 

--- a/src/windows/qdss/QDBRD.h
+++ b/src/windows/qdss/QDBRD.h
@@ -14,12 +14,7 @@ GENERAL DESCRIPTION
 #ifndef QDBRD_H
 #define QDBRD_H
 
-VOID QDBRD_IoRead
-(
-    WDFQUEUE   Queue,
-    WDFREQUEST Request,
-    size_t     Length
-);
+EVT_WDF_IO_QUEUE_IO_READ QDBRD_IoRead;
 
 VOID QDBRD_ReadUSB
 (
@@ -28,13 +23,7 @@ VOID QDBRD_ReadUSB
     IN ULONG            Length
 );
 
-VOID QDBRD_ReadUSBCompletion
-(
-    WDFREQUEST                  Request,
-    WDFIOTARGET                 Target,
-    PWDF_REQUEST_COMPLETION_PARAMS CompletionParams,
-    WDFCONTEXT                  Context
-);
+EVT_WDF_REQUEST_COMPLETION_ROUTINE QDBRD_ReadUSBCompletion;
 
 NTSTATUS QDBRD_AllocateRequestsRx(PDEVICE_CONTEXT pDevContext);
 
@@ -48,13 +37,7 @@ VOID QDBRD_SendIOBlock(PDEVICE_CONTEXT pDevContext, INT Index);
 
 NTSTATUS QDBRD_PipeDrainStop(PDEVICE_CONTEXT pDevContext);
 
-VOID QDBRD_PipeDrainCompletion
-(
-    WDFREQUEST                  Request,
-    WDFIOTARGET                 Target,
-    PWDF_REQUEST_COMPLETION_PARAMS CompletionParams,
-    WDFCONTEXT                  Context
-);
+EVT_WDF_REQUEST_COMPLETION_ROUTINE QDBRD_PipeDrainCompletion;
 
 VOID QDBRD_ProcessDrainedDPLBlock(PDEVICE_CONTEXT pDevContext, PVOID Buffer, ULONG Length);
 

--- a/src/windows/qdss/QDBWT.h
+++ b/src/windows/qdss/QDBWT.h
@@ -14,12 +14,7 @@ GENERAL DESCRIPTION
 #ifndef QDBWT_H
 #define QDBWT_H
 
-VOID QDBWT_IoWrite
-(
-    WDFQUEUE   Queue,
-    WDFREQUEST Request,
-    size_t     Length
-);
+EVT_WDF_IO_QUEUE_IO_WRITE QDBWT_IoWrite;
 
 VOID QDBWT_WriteUSB
 (
@@ -28,12 +23,6 @@ VOID QDBWT_WriteUSB
     IN ULONG            Length
 );
 
-VOID QDBWT_WriteUSBCompletion
-(
-    WDFREQUEST                  Request,
-    WDFIOTARGET                 Target,
-    PWDF_REQUEST_COMPLETION_PARAMS CompletionParams,
-    WDFCONTEXT                  Context
-);
+EVT_WDF_REQUEST_COMPLETION_ROUTINE QDBWT_WriteUSBCompletion;
 
 #endif // QDBWT_H

--- a/src/windows/transport/usb/USBDSP.c
+++ b/src/windows/transport/usb/USBDSP.c
@@ -24,7 +24,7 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "USBDSP.tmh"
 
 #endif   // EVENT_TRACING
@@ -1539,8 +1539,8 @@ void USBDSP_GetMUXInterface(PDEVICE_EXTENSION  pDevExt, UCHAR InterfaceNumber)
 
     IoSetCompletionRoutine(
         pIrp,
-        (PIO_COMPLETION_ROUTINE)USBDSP_GetMUXInterfaceCompletion,
-        (PVOID)pDevExt,
+        USBDSP_GetMUXInterfaceCompletion,
+        pDevExt,
         TRUE, TRUE, TRUE
     );
 
@@ -2331,7 +2331,7 @@ NTSTATUS USBDSP_Dispatch
             ntStatus = IoCallDriver(pUsbDevObject, Irp);
             QcIoReleaseRemoveLock(pDevExt->pRemoveLock, Irp, 0);
             goto USBDSP_Dispatch_Done; // the USBD stack took care of it
-            break;         // power           
+            break;         // power
         } // IRP_MJ_SYSTEM_CONTROL i.e. WMI
         default:
         {
@@ -2347,7 +2347,7 @@ NTSTATUS USBDSP_Dispatch
             // Bypass the IoCompleteRequest since the USBD stack took care of it
             QcIoReleaseRemoveLock(pDevExt->pRemoveLock, Irp, 0);
             goto USBDSP_Dispatch_Done;
-            break;  // power           
+            break;  // power
         }
     }// switch majorfunction
 

--- a/src/windows/transport/usb/USBDSP.h
+++ b/src/windows/transport/usb/USBDSP.h
@@ -41,4 +41,6 @@ BOOLEAN QCDSP_ToProcessIrp
 );
 void USBDSP_GetMUXInterface(PDEVICE_EXTENSION  pDevExt, UCHAR InterfaceNumber);
 
+IO_COMPLETION_ROUTINE USBDSP_GetMUXInterfaceCompletion;
+
 #endif // USBDSP_H

--- a/src/windows/transport/usb/USBINT.c
+++ b/src/windows/transport/usb/USBINT.c
@@ -19,7 +19,7 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "USBINT.tmh"
 
 #endif   // EVENT_TRACING
@@ -366,8 +366,8 @@ VOID ReadInterruptPipe(IN PVOID pContext)
             IoSetCompletionRoutine
             (
                 pIrp,
-                (PIO_COMPLETION_ROUTINE)InterruptPipeCompletion,
-                (PVOID)pDevExt,
+                InterruptPipeCompletion,
+                pDevExt,
                 TRUE,
                 TRUE,
                 TRUE
@@ -999,7 +999,7 @@ wait_for_completion:
     if (pIrp != NULL)
     {
         IoReuseIrp(pIrp, STATUS_SUCCESS);
-        IoFreeIrp(pIrp); // free irp 
+        IoFreeIrp(pIrp); // free irp
     }
     if (pwbArray != NULL)
     {

--- a/src/windows/transport/usb/USBINT.h
+++ b/src/windows/transport/usb/USBINT.h
@@ -41,12 +41,6 @@ typedef struct _USB_NOTIFICATION_CONNECTION_SPEED
 
 NTSTATUS USBINT_InitInterruptPipe(IN PDEVICE_OBJECT pDevObj);
 VOID ReadInterruptPipe(IN PVOID pContext);
-NTSTATUS InterruptPipeCompletion
-(
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PIRP           pIrp,
-    IN PVOID          pContext
-);
 NTSTATUS USBINT_CancelInterruptThread(PDEVICE_EXTENSION pDevExt, UCHAR cookie);
 NTSTATUS USBINT_StopInterruptService
 (
@@ -61,5 +55,7 @@ VOID USBINT_HandleSerialStateNotification(PDEVICE_EXTENSION pDevExt);
 VOID USBINT_HandleNetworkConnectionNotification(PDEVICE_EXTENSION pDevExt);
 VOID USBINT_HandleResponseAvailableNotification(PDEVICE_EXTENSION pDevExt);
 VOID USBINT_HandleConnectionSpeedChangeNotification(PDEVICE_EXTENSION pDevExt);
+
+IO_COMPLETION_ROUTINE InterruptPipeCompletion;
 
 #endif // USBINT_H

--- a/src/windows/transport/usb/USBPNP.c
+++ b/src/windows/transport/usb/USBPNP.c
@@ -30,7 +30,7 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "USBPNP.tmh"
 
 #endif   // EVENT_TRACING
@@ -585,8 +585,8 @@ NTSTATUS QCPNP_GetParentDeviceName(PDEVICE_EXTENSION pDevExt)
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)QCPNP_GenericCompletion,
-        (PVOID)pDevExt,
+        QCPNP_GenericCompletion,
+        pDevExt,
         TRUE, TRUE, TRUE
     );
 
@@ -2211,7 +2211,7 @@ NTSTATUS USBPNP_InitDevExt
     pDevExt->IoBusyMask = 0;
     pDevExt->SelectiveSuspendIdleTime = 10;  // chage it to 5 by default
     pDevExt->SelectiveSuspendInMili = FALSE;
-    pDevExt->InServiceSelectiveSuspension = FALSE;  // disable for 5G data for now -- TODO 
+    pDevExt->InServiceSelectiveSuspension = FALSE;  // disable for 5G data for now -- TODO
     pDevExt->bRemoteWakeupEnabled = FALSE;  // hardcode for now
     pDevExt->bDeviceSelfPowered = FALSE;
     pDevExt->PowerManagementEnabled = TRUE;
@@ -2235,7 +2235,7 @@ NTSTATUS USBPNP_InitDevExt
         );
     }
 
-#endif 
+#endif
 
 USBPNP_InitDevExt_Return:
     if (pucNewReadBuffer)

--- a/src/windows/transport/usb/USBPNP.h
+++ b/src/windows/transport/usb/USBPNP.h
@@ -97,4 +97,6 @@ NTSTATUS QCPNP_GetStringDescriptor
     BOOLEAN        MatchPrefix
 );
 
+IO_COMPLETION_ROUTINE QCPNP_GenericCompletion;
+
 #endif // USBPNP_H

--- a/src/windows/transport/usb/USBPWR.c
+++ b/src/windows/transport/usb/USBPWR.c
@@ -22,7 +22,7 @@ GENERAL DESCRIPTION
 // EVENT_TRACING
 #ifdef EVENT_TRACING
 
-#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc 
+#include "MPWPP.h"               // Driver specific WPP Macros, Globals, etc
 #include "USBPWR.tmh"
 
 #endif   // EVENT_TRACING
@@ -94,7 +94,7 @@ VOID QCPWR_PowrerManagement
                         IoSetCompletionRoutine
                         (
                             Irp,
-                            (PIO_COMPLETION_ROUTINE)QCPWR_SystemPowerRequestCompletion,
+                            QCPWR_SystemPowerRequestCompletion,
                             pDevExt, TRUE, TRUE, TRUE
                         );
                     }
@@ -124,7 +124,7 @@ VOID QCPWR_PowrerManagement
                         IoSetCompletionRoutine
                         (
                             Irp,
-                            (PIO_COMPLETION_ROUTINE)QCPWR_DevicePowerDownIrpCompletion,
+                            QCPWR_DevicePowerDownIrpCompletion,
                             pDevExt, TRUE, TRUE, TRUE
                         );
                     }
@@ -183,7 +183,7 @@ VOID QCPWR_PowrerManagement
                     IoSetCompletionRoutine
                     (
                         Irp,
-                        (PIO_COMPLETION_ROUTINE)QCPWR_SystemPowerRequestCompletion,
+                        QCPWR_SystemPowerRequestCompletion,
                         pDevExt, TRUE, TRUE, TRUE
                     );
 
@@ -949,7 +949,7 @@ NTSTATUS QCPWR_SetDevicePowerState
             IoSetCompletionRoutine
             (
                 Irp,
-                (PIO_COMPLETION_ROUTINE)QCPWR_DevicePowerUpIrpCompletion,
+                QCPWR_DevicePowerUpIrpCompletion,
                 pDevExt,
                 TRUE, TRUE, TRUE
             );
@@ -1083,7 +1083,7 @@ NTSTATUS QCPWR_DecreaseDevicePower
     IoSetCompletionRoutine
     (
         Irp,
-        (PIO_COMPLETION_ROUTINE)QCPWR_DevicePowerDownIrpCompletion,
+        QCPWR_DevicePowerDownIrpCompletion,
         pDevExt,
         TRUE, TRUE, TRUE
     );
@@ -2436,7 +2436,7 @@ VOID QCPWR_ProcessWaitWake(PDEVICE_EXTENSION pDevExt, PIRP Irp)
     IoSetCompletionRoutine
     (
         Irp,
-        (PIO_COMPLETION_ROUTINE)QCPWR_WaitWakeCompletion,
+        QCPWR_WaitWakeCompletion,
         pDevExt,
         TRUE, TRUE, TRUE
     );
@@ -3732,7 +3732,7 @@ VOID USBPWR_StopExWdmDeviceMonitor(PDEVICE_EXTENSION pDevExt)
         IoUnregisterPlugPlayNotification(pDevExt->ExWdmIfNotificationEntry);
         pDevExt->ExWdmIfNotificationEntry = NULL;
     }
-} // USBPWR_StopExWdmDeviceMonitor 
+} // USBPWR_StopExWdmDeviceMonitor
 
 NTSTATUS USBPWR_DeviceInterfaceChange
 (
@@ -4270,8 +4270,8 @@ SYSTEM_POWER_STATE USBPWR_GetSystemPowerState
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)USBPWR_GetSysPowerIrpCompletion,
-        (PVOID)pDevExt,
+        USBPWR_GetSysPowerIrpCompletion,
+        pDevExt,
         TRUE, TRUE, TRUE
     );
 
@@ -4339,8 +4339,8 @@ NTSTATUS USBPWR_RegisterXwdmNotification(PDEVICE_EXTENSION pDevExt)
     IoSetCompletionRoutine
     (
         pIrp,
-        (PIO_COMPLETION_ROUTINE)USBPWR_ExWdmDevNotifyCompletion,
-        (PVOID)pDevExt,
+        USBPWR_ExWdmDevNotifyCompletion,
+        pDevExt,
         TRUE, TRUE, TRUE
     );
 

--- a/src/windows/transport/usb/USBPWR.h
+++ b/src/windows/transport/usb/USBPWR.h
@@ -14,6 +14,14 @@ GENERAL DESCRIPTION
 
 #include "USBMAIN.h"
 
+IO_COMPLETION_ROUTINE QCPWR_SystemPowerRequestCompletion;
+IO_COMPLETION_ROUTINE QCPWR_DevicePowerDownIrpCompletion;
+IO_COMPLETION_ROUTINE QCPWR_DevicePowerUpIrpCompletion;
+IO_COMPLETION_ROUTINE QCPWR_WaitWakeCompletion;
+IO_COMPLETION_ROUTINE QCPWR_IdleNotificationIrpCompletion;
+IO_COMPLETION_ROUTINE USBPWR_GetSysPowerIrpCompletion;
+IO_COMPLETION_ROUTINE USBPWR_ExWdmDevNotifyCompletion;
+
 #define QCUSB_SS_IDLE_MIN         3  // seconds
 #define QCUSB_SS_IDLE_MAX       120  // seconds
 #define QCUSB_SS_IDLE_DEFAULT     5  // seconds
@@ -144,13 +152,6 @@ NTSTATUS QCPWR_SetDevicePowerState
     DEVICE_POWER_STATE PowerState
 );
 
-NTSTATUS QCPWR_SystemPowerRequestCompletion
-(
-    PDEVICE_OBJECT    DeviceObject,
-    PIRP              Irp,
-    PDEVICE_EXTENSION pDevExt
-);
-
 VOID QCPWR_RequestDevicePowerIrp
 (
     PDEVICE_EXTENSION pDevExt,
@@ -166,20 +167,6 @@ VOID QCPWR_TopDevicePowerIrpCompletionRoutine
     POWER_STATE PowerState,
     PVOID Context,
     PIO_STATUS_BLOCK IoStatus
-);
-
-NTSTATUS QCPWR_DevicePowerUpIrpCompletion
-(
-    PDEVICE_OBJECT    DeviceObject,
-    PIRP              Irp,
-    PDEVICE_EXTENSION pDevExt
-);
-
-NTSTATUS QCPWR_DevicePowerDownIrpCompletion
-(
-    PDEVICE_OBJECT    DeviceObject,
-    PIRP              Irp,
-    PDEVICE_EXTENSION pDevExt
 );
 
 NTSTATUS QCPWR_DecreaseDevicePower
@@ -243,13 +230,6 @@ VOID QCPWR_TopDeviceSetPowerIrpCompletionRoutine
     PIO_STATUS_BLOCK IoStatus
 );
 
-NTSTATUS QCPWR_IdleNotificationIrpCompletion
-(
-    PDEVICE_OBJECT          DeviceObject,
-    PIRP                    Irp,
-    PUSB_IDLE_CALLBACK_INFO IdleCallbackInfo
-);
-
 VOID QCPWR_GetOutOfIdleState(PDEVICE_EXTENSION pDevExt);
 
 NTSTATUS QCPWR_IdleNotificationIrpCompletionEpisode
@@ -274,13 +254,6 @@ VOID QCPWR_CancelIdleNotificationIrp(PDEVICE_EXTENSION pDevExt, UCHAR Cookie);
 //          Wait-Wake
 // ========================================================
 VOID QCPWR_ProcessWaitWake(PDEVICE_EXTENSION pDevExt, PIRP Irp);
-
-NTSTATUS QCPWR_WaitWakeCompletion
-(
-    PDEVICE_OBJECT    DeviceObject,
-    PIRP              Irp,
-    PDEVICE_EXTENSION pDevExt
-);
 
 VOID QCPWR_RegisterWaitWakeIrp(PDEVICE_EXTENSION  pDevExt, UCHAR Cookie);
 

--- a/src/windows/wdfserial/QCPNP.h
+++ b/src/windows/wdfserial/QCPNP.h
@@ -126,13 +126,7 @@ NTSTATUS QCPNP_RegisterDevName
     ULONG       BufferLength
 );
 
-void QCPNP_RegisterDevNameCompletion
-(
-    WDFREQUEST  Request,
-    WDFIOTARGET Target,
-    PWDF_REQUEST_COMPLETION_PARAMS Params,
-    WDFCONTEXT  Context
-);
+EVT_WDF_REQUEST_COMPLETION_ROUTINE QCPNP_RegisterDevNameCompletion;
 
 NTSTATUS QCPNP_RegisterWmiPowerGuid
 (

--- a/src/windows/wdfserial/QCRD.h
+++ b/src/windows/wdfserial/QCRD.h
@@ -68,12 +68,6 @@ BOOLEAN QCRD_StartReadTimeout
     ULONG readLength
 );
 
-VOID QCRD_ReadTimeoutDpc
-(
-    IN PKDPC Dpc,
-    IN PVOID DeferredContext,
-    IN PVOID SystemArgument1,
-    IN PVOID SystemArgument2
-);
+KDEFERRED_ROUTINE QCRD_ReadTimeoutDpc;
 
 #endif


### PR DESCRIPTION
This pull request resolves the follwing CodeQL Static Analysis error:
1. cpp/drivers/extended-deprecated-apis
2. cpp/drivers/wdk-deprecated-api
3. cpp/drivers/role-type-correctly-used

This pull request included the follwing changes:
1. Replaced deprecated APIs ExAllocatePool, sprint, strcpy with secured versions
2. Updated function declaration for some callbacks to use WDK role types
3. Removed unreferenced function declaration