### PR TITLE
Fix Windows DUN error 619 caused by missing serial events and incorrect queue state

### DIFF
--- a/src/windows/wdfserial/QCRD.c
+++ b/src/windows/wdfserial/QCRD.c
@@ -582,7 +582,7 @@ void QCRD_ReadRequestHandlerThread
                                 if (QCRD_StartReadTimeout(pDevContext, (ULONG)requestParam.Parameters.Read.Length) == FALSE)
                                 {
                                     // timeout immediately
-                                    WdfRequestComplete(pendingTimeoutRequest, STATUS_TIMEOUT);
+                                    WdfRequestComplete(pendingTimeoutRequest, STATUS_SUCCESS);
                                     QCSER_DbgPrint
                                     (
                                         QCSER_DBG_MASK_READ,

--- a/src/windows/wdfserial/QCSER.c
+++ b/src/windows/wdfserial/QCSER.c
@@ -177,7 +177,7 @@ VOID QCSER_ProcessNewUartState
 
         pDevContext->CurrUartState &= US_BITS_MODEM;
         ulNewEvent &= pDevContext->WaitMask;
-        QCSER_CompleteWomRequest(pDevContext, STATUS_SUCCESS, pDevContext->WaitMask);
+        QCSER_CompleteWomRequest(pDevContext, STATUS_SUCCESS, ulNewEvent);
     }
 
     QCSER_DbgPrint

--- a/src/windows/wdfserial/QCUTILS.c
+++ b/src/windows/wdfserial/QCUTILS.c
@@ -292,7 +292,7 @@ BOOLEAN QCUTIL_IsIoQueueEmpty
         NULL,
         NULL
     );
-    return (WDF_IO_QUEUE_IDLE(queueStatus)) ? TRUE : FALSE;
+    return ((queueStatus & WdfIoQueueNoRequests) != 0);
 }
 
 


### PR DESCRIPTION
### Summary
This change fixes multiple issues in the serial driver that caused Windows Dial‑Up Networking to fail with **error 619**. 

### Error Description
Repro: Initiate a dial-up connection against the Qualcomm modem on Windows Settings. The **error 619** will pop up:

<img width="387" height="280" alt="image" src="https://github.com/user-attachments/assets/db22399d-e5f6-4b71-a087-cdbeb9e7dd61" />

### Root Cause Analysis (RCA)

1. **Wrong output mask for WAIT_ON_MASK**  
   The driver completed `IOCTL_SERIAL_WAIT_ON_MASK` with an incorrect output event mask, so the application never observed `SERIAL_EV_RXFLAG`. As a result, the dial‑up flow could not proceed.

2. **Queue state mis‑reporting rejected new WOM requests**  
   The logic used to determine whether the framework queue is empty was incorrect. Under certain race conditions, the application had already acknowledged the completion of the previous WAIT_ON_MASK request, but the driver still perceived the queue as non‑empty. As a result, the application restarted the connection by purging the RX buffer, which made all subsequent WAIT_ON_MASK requests were continuously rejected.

3. **Potentially incorrect return status for immediate timeout**  
   Immediate timeout paths (Type 4/6) returned `STATUS_TIMEOUT`. The upper layer **may** interpreted this as a terminal failure.

### Validation

Validated with Qualcomm modem on Windows 11 24h2, the **error 619** is gone.