### PR TITLE
Fix compilation error on kernel 6.17 and later

### DIFF
--- a/src/linux/qcom_usbnet/qcom_usbnet_main.c
+++ b/src/linux/qcom_usbnet/qcom_usbnet_main.c
@@ -2871,8 +2871,13 @@ int GobiUSBNetProbe(
    pGobiDev->ULAggregationMaxSize = pGobiDev->tx_aggr_ctx.tx_max;
    pGobiDev->ULAggregationMaxDatagram = pGobiDev->tx_aggr_ctx.tx_max_datagrams;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
+   hrtimer_setup(&pGobiDev->tx_aggr_ctx.tx_timer, cdc_ncm_tx_timer_cb, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+#else
    hrtimer_init(&pGobiDev->tx_aggr_ctx.tx_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
    pGobiDev->tx_aggr_ctx.tx_timer.function = &cdc_ncm_tx_timer_cb;
+#endif
+
    //TODO:: you can use tasklet_init and can use tasklet_hi_schedule instead tasklet_schedule
    pGobiDev->tx_aggr_ctx.bh.data = (unsigned long)pDev;
    pGobiDev->tx_aggr_ctx.bh.func = cdc_ncm_txpath_bh;


### PR DESCRIPTION
### Summary
Linux drivers fail to compile when using Ubuntu 24.04 with Kernel 6.17.

### Solution
Added a kernel version check in GobiUSBNetProbe(), qcom_usbnet_main.c to use hrtimer_setup() if kernel version >= 6.17