### PR TITLE
Enable QUD driver support for linux kernel v6.15, v6.16 and v6.17

### DIFF
--- a/src/linux/qcom_usb/qcom_usb_main.c
+++ b/src/linux/qcom_usb/qcom_usb_main.c
@@ -1714,12 +1714,7 @@ static ssize_t UserspaceQTIDevWrite(struct file *file, const char *user_buffer,
     {
         // timeout, cancel what's on the anchor
         QC_LOG_WARN(pDev, "QTI TX timeout: planned size %lu TxCount %ld\n", dataLen, pDev->mStats.TxCount);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)) || \
-    (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 1))
-        usb_unpoison_anchored_urbs(txAnchor);
-#else
-        usb_unlink_anchored_urbs(txAnchor);
-#endif
+        usb_kill_anchored_urbs(txAnchor);
     }
 
     down(&writeSem); // make it non-interruptible

--- a/src/linux/qcom_usbnet/qcom_usbnet_main.c
+++ b/src/linux/qcom_usbnet/qcom_usbnet_main.c
@@ -1857,9 +1857,7 @@ static void cdc_ncm_txpath_bh(unsigned long param)
 {
     struct usbnet *dev = (struct usbnet *)param;
     sGobiUSBNet *pGobiDev = (sGobiUSBNet *)dev->data[0];
-    struct rm_cdc_ncm_ctx *ctx;
-
-    ctx = &pGobiDev->tx_aggr_ctx;
+    struct rm_cdc_ncm_ctx *ctx = &pGobiDev->tx_aggr_ctx;
 
    spin_lock_bh(&ctx->mtx);
    if (ctx->tx_timer_pending != 0) {
@@ -2871,11 +2869,14 @@ int GobiUSBNetProbe(
    pGobiDev->ULAggregationMaxSize = pGobiDev->tx_aggr_ctx.tx_max;
    pGobiDev->ULAggregationMaxDatagram = pGobiDev->tx_aggr_ctx.tx_max_datagrams;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+   hrtimer_setup(&pGobiDev->tx_aggr_ctx.tx_timer, &cdc_ncm_tx_timer_cb,
+                 CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+#else
    hrtimer_init(&pGobiDev->tx_aggr_ctx.tx_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
    pGobiDev->tx_aggr_ctx.tx_timer.function = &cdc_ncm_tx_timer_cb;
-   //TODO:: you can use tasklet_init and can use tasklet_hi_schedule instead tasklet_schedule
-   pGobiDev->tx_aggr_ctx.bh.data = (unsigned long)pDev;
-   pGobiDev->tx_aggr_ctx.bh.func = cdc_ncm_txpath_bh;
+#endif
+   tasklet_init(&pGobiDev->tx_aggr_ctx.bh, cdc_ncm_txpath_bh, (unsigned long)pDev);
    atomic_set(&pGobiDev->tx_aggr_ctx.stop, 0);
 
    spin_lock_init(&pGobiDev->tx_aggr_ctx.mtx);


### PR DESCRIPTION
1. QdssDiag driver - File: qcom_usb/qcom_usb_main.c

Starting with kernel 6.17, the API usb_unlink_anchored_urbs() was removed from the USB core subsystem. This API was previously used to unlink outstanding URBs. To remove kernel‑version‑specific dependencies, we eliminated depedency on usb_unlink_anchored_urbs().
An alternative approach using a combination of usb_poison_anchored_urbs() and usb_unpoison_anchored_urbs()
While poisoning prevents submission of new URBs and subsequent internal calling of usb_poision_urb() drains pending URB's, and usb_unpoison_anchored_urbs() only clears the poisoned flag and does not cancel existing URBs. I identified that an earlier implementation incorrectly used only usb_unpoison_anchored_urbs(), which did not cancel pending URBs. So I have removed the implementation.

Best approach- consistent with our driver - using usb_kill_anchored_urbs()- is to explicitly kill all outstanding URBs and wait for their completion without poisoning the anchor.

2. RMNET driver -  File: qcom_usbnet/qcom_usbnet_main.c

Starting with kernel 6.15, hrtimer_init() was removed and replaced with hrtimer_setup().
Implemented tasklet_init() in place of direct assignment to .data and .func - aligning with upstream kernel guidelines and earlier my TODO comments.

https://www.kernel.org/doc/html/v6.6/driver-api/usb/usb.html

