### PR TITLE
Fix Windows driver build compatibility with modern WDK/SDK

### DIFF
--- a/src/windows/filter/qcusbfilter.vcxproj
+++ b/src/windows/filter/qcusbfilter.vcxproj
@@ -42,10 +42,11 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>qcfilter</RootNamespace>
+    <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -54,7 +55,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -63,7 +64,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -72,7 +73,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -81,7 +82,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
-    <TargetVersion>Windows8</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -90,7 +91,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
-    <TargetVersion>Windows8</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>

--- a/src/windows/ndis/MPMain.h
+++ b/src/windows/ndis/MPMain.h
@@ -18,6 +18,13 @@ GENERAL DESCRIPTION
 #include <windef.h>
 #include <wwan.h>
 #include <ndiswwan.h>
+// Compatibility defines for deprecated 5G data class constants (removed in newer WDK)
+#ifndef WWAN_DATA_CLASS_5G_EPC
+#define WWAN_DATA_CLASS_5G_EPC      WWAN_DATA_CLASS_5G    // 0x00000040
+#endif
+#ifndef WWAN_DATA_CLASS_5G_5GC
+#define WWAN_DATA_CLASS_5G_5GC      0x00000080            // retired, now WWAN_DATA_CLASS_UNUSED
+#endif
 #endif //NDIS620_MINIPORT
 #include "MPParam.h"
 #include "MPQMI.h"

--- a/src/windows/ndis/qcusbnet.vcxproj
+++ b/src/windows/ndis/qcusbnet.vcxproj
@@ -34,11 +34,12 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>qcusbnet</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -46,7 +47,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -54,7 +55,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -72,7 +73,7 @@
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <TargetVersion>Windows7</TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>


### PR DESCRIPTION
This commit updates the Windows kernel driver projects (USB filter driver and NDIS miniport driver) to build successfully with modern Windows Driver Kit (WDK) and Windows SDK versions.

Changes:
1. TargetVersion updated from Windows7/Windows8 to Windows10 across all 6 build configurations (Debug/Release × Win32/x64/ARM). The older Windows7/Windows8 target versions are no longer supported by current WDK toolchains and cause build failures.
2. Added <FileDigestAlgorithm>sha256</FileDigestAlgorithm> to the global property group. Modern driver signing requires SHA-256 digest; SHA-1 is deprecated and rejected by Windows 10+ enforcement policies.
3. WindowsTargetPlatformVersion changed from hardcoded 10.0.19041.0 → $(LatestTargetPlatformVersion). This MSBuild property resolves to whatever SDK is installed on the build machine, eliminating build failures when the exact SDK version (19041) is not present.
4. Added compatibility #defines for WWAN_DATA_CLASS_5G_EPC and WWAN_DATA_CLASS_5G_5GC. These constants were deprecated/removed in newer WDK headers. The #ifndef guards provide fallback definitions so the driver source compiles against both older and newer WDK versions without modification:
WWAN_DATA_CLASS_5G_EPC → maps to WWAN_DATA_CLASS_5G (0x00000040)
WWAN_DATA_CLASS_5G_5GC → hardcoded to 0x00000080 (retired constant, now WWAN_DATA_CLASS_UNUSED)