### PR TITLE
Add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
-name: Dependabots scan
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # This points to .github/workflows
     schedule:
       interval: "daily"
+


### PR DESCRIPTION
- Adds .github/dependabot.yml to enable automated dependency updates via GitHub Dependabot. It is configured to:

  Monitor GitHub Actions workflow dependencies (.github/workflows/)
  Check for updates daily and automatically open PRs when newer versions of used actions are available
  This ensures CI/CD workflows always use up-to-date, patched versions of GitHub Actions, reducing exposure to known vulnerabilities in third-party actions.