### PR TITLE
fix: filter ARM build with Windows10 target

### DIFF
--- a/src/windows/filter/qcusbfilter.vcxproj
+++ b/src/windows/filter/qcusbfilter.vcxproj
@@ -87,7 +87,7 @@
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>WDM</DriverType>
-    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
@@ -96,7 +96,7 @@
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>WDM</DriverType>
-    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">


### PR DESCRIPTION
Problem:
Building qcusbfilter for ARM 32-bit fails with:
  error: The 'Desktop' target platform is not supported by the target
  OS 'Windows10' for 'ARM'.

Root Cause:
The WDK does not allow DriverTargetPlatform=Desktop with TargetVersion=Windows10 on ARM 32-bit. The Desktop platform was valid for older TargetVersions like Windows8 but not Windows10.

Fix:
Changed DriverTargetPlatform from Desktop to Universal for Debug|ARM and Release|ARM configs in qcusbfilter.vcxproj. This matches the pattern already used by qcwdfserial (Universal for all configs) and qcusbnet (Universal for ARM64).

Test:
Full buildQikInstaller.bat completed successfully with all drivers built for all architectures (amd64, arm, arm64, i386). Output verified at target\fre\Windows10\ with matching .sys, .cat, and .inf files.

