### PR TITLE
 wdfserial: fix NULL pipe guards and divide-by-zero in read/write threads

### DIFF
--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -3112,6 +3112,18 @@ NTSTATUS QCPNP_ResetUsbPipe
 )
 {
     NTSTATUS status = STATUS_SUCCESS;
+
+    if (usbPipe == NULL)
+    {
+        QCSER_DbgPrint
+        (
+            QCSER_DBG_MASK_CIRP,
+            QCSER_DBG_LEVEL_ERROR,
+            ("<%ws> QCPNP_ResetUsbPipe called with NULL pipe, skipping\n", pDevContext->PortName)
+        );
+        return STATUS_SUCCESS;
+    }
+
     WDFIOTARGET ioTarget = WdfUsbTargetPipeGetIoTarget(usbPipe);
     WDF_REQUEST_SEND_OPTIONS syncReqOptions;
     WDF_REQUEST_SEND_OPTIONS_INIT(&syncReqOptions, 0);

--- a/src/windows/wdfserial/QCRD.c
+++ b/src/windows/wdfserial/QCRD.c
@@ -132,8 +132,8 @@ void QCRD_ReadRequestHandlerThread
     PREQUEST_CONTEXT pReqContext;
     PDEVICE_CONTEXT  pDevContext = pContext;
     ULONG            devErrCnt = 0;
-    WDFIOTARGET      ioTarget = WdfUsbTargetPipeGetIoTarget(pDevContext->BulkIN);
-    PKWAIT_BLOCK     pWaitBlock = ExAllocatePoolUninitialized(NonPagedPoolNx, (READ_THREAD_RESUME_EVENT_COUNT) * sizeof(KWAIT_BLOCK), '3gaT');
+    WDFIOTARGET      ioTarget = NULL;
+    PKWAIT_BLOCK     pWaitBlock = NULL;
     BOOLEAN          bRunning = TRUE;
     BOOLEAN          bDeviceOpened = FALSE;
     BOOLEAN          bDeviceAwaken = FALSE;
@@ -143,6 +143,22 @@ void QCRD_ReadRequestHandlerThread
     PREAD_BUFFER_PARAM pBufferParam;        // for read urbs
     WDF_REQUEST_PARAMETERS requestParam;    // for application requests
     PRING_BUFFER rxBuffer = &pDevContext->ReadRingBuffer;
+
+    if (pDevContext->BulkIN == NULL)
+    {
+        QCSER_DbgPrint
+        (
+            QCSER_DBG_MASK_READ,
+            QCSER_DBG_LEVEL_ERROR,
+            ("<%ws> RIRP: QCRD_ReadRequestHandlerThread ERROR no USB pipe for read, exiting\n", pDevContext->PortName)
+        );
+        KeSetEvent(&pDevContext->ReadThreadStartedEvent, IO_NO_INCREMENT, FALSE);
+        PsTerminateSystemThread(STATUS_SUCCESS);
+        return;
+    }
+
+    ioTarget = WdfUsbTargetPipeGetIoTarget(pDevContext->BulkIN);
+    pWaitBlock = ExAllocatePoolUninitialized(NonPagedPoolNx, (READ_THREAD_RESUME_EVENT_COUNT) * sizeof(KWAIT_BLOCK), '3gaT');
 
     if (pWaitBlock == NULL)
     {

--- a/src/windows/wdfserial/QCWT.c
+++ b/src/windows/wdfserial/QCWT.c
@@ -403,7 +403,7 @@ void QCWT_WriteRequestHandlerThread
                         WDF_REQUEST_PARAMETERS_INIT(&writeParam);
                         WdfRequestGetParameters(request, &writeParam);
                         QCWT_EvtIoWrite(pDevContext->WriteQueue, request, writeParam.Parameters.Write.Length);
-                        if (gVendorConfig.EnableZeroLengthPacket && (writeParam.Parameters.Write.Length % pDevContext->wMaxPktSize == 0))
+                        if (gVendorConfig.EnableZeroLengthPacket && (pDevContext->wMaxPktSize != 0) && (writeParam.Parameters.Write.Length % pDevContext->wMaxPktSize == 0))
                         {
 #ifdef QCUSB_MUX_PROTOCOL
                             if (pDevContext->DeviceFunction != QCUSB_DEV_FUNC_LPC)


### PR DESCRIPTION
## Bug 1 — NULL pipe in QCPNP_ResetUsbPipe

QCPNP_ResetUsbPipe() calls WdfUsbTargetPipeGetIoTarget() and WdfIoTargetStop() without validating that the pipe handle is non-NULL. On multi-interface USB composite devices, certain interface functions may lack bulk IN or bulk OUT endpoints, leaving BulkIN/BulkOUT as NULL in the device context. When callers such as EvtDevicePrepareHardware or EvtFileCreate pass these NULL handles to QCPNP_ResetUsbPipe, the WDF framework raises a WDF_VIOLATION (bugcheck 0x10D) because the WDFUSBPIPE handle is invalid.

### Fix
Add a NULL check at the entry of QCPNP_ResetUsbPipe to return STATUS_SUCCESS early when the pipe handle is NULL.

## Bug 2 — Integer divide-by-zero in write thread (QUD-1832)

QCWT_WriteRequestHandlerThread performs `writeParam.Parameters.Write.Length % pDevContext->wMaxPktSize` to decide whether a zero-length USB packet is needed. When the bulk-OUT pipe is not yet configured (or during surprise removal / power transition), `wMaxPktSize` is 0, causing a SYSTEM_SERVICE_EXCEPTION (bugcheck 0xC0000094 — integer divide-by-zero).

Crash signature: `qcwdfserial+0x1370f`, `rax=0x9` (write length), `r8=0x0` (wMaxPktSize).

### Fix
Add `pDevContext->wMaxPktSize != 0` guard before the modulo in QCWT_WriteRequestHandlerThread. C short-circuit evaluation skips the division when the packet size is zero.

## Bug 3 — NULL BulkIN dereference in read handler thread

QCRD_ReadRequestHandlerThread unconditionally calls `WdfUsbTargetPipeGetIoTarget(pDevContext->BulkIN)` at thread start. When the USB device has no bulk-IN endpoint (e.g., control-only or output-only interfaces), BulkIN is NULL and the WDF framework dereferences an invalid handle, causing a BSOD.

### Fix
Add a NULL check for `pDevContext->BulkIN` at the top of the read handler thread. If NULL, signal the thread-started event and exit gracefully via PsTerminateSystemThread, matching the existing NULL guard pattern in the write path.

## Testing

- Verified on a composite USB device with missing bulk endpoints — no BSOD on device attach/open.
- Existing paths with valid pipe handles are unaffected.
- Zero-length-packet logic is correctly skipped when wMaxPktSize is 0.
- Read thread exits cleanly when BulkIN pipe is absent.

Fixes: QUD-1832