### PR TITLE
Add .pdb copy to package in .vxproj build configuration

### DIFF
--- a/src/windows/filter/qcusbfilter.vcxproj
+++ b/src/windows/filter/qcusbfilter.vcxproj
@@ -292,6 +292,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
+	<FilesToPackage Include="$(OutDir)$(TargetName).pdb" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\qcversion.h" />

--- a/src/windows/ndis/qcusbnet.vcxproj
+++ b/src/windows/ndis/qcusbnet.vcxproj
@@ -229,6 +229,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
+	<FilesToPackage Include="$(OutDir)$(TargetName).pdb" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\transport\usb\USBCTL.c" />

--- a/src/windows/qdss/qdbusb.vcxproj
+++ b/src/windows/qdss/qdbusb.vcxproj
@@ -242,6 +242,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
+	<FilesToPackage Include="$(OutDir)$(TargetName).pdb" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="QDBDEV.c" />

--- a/src/windows/wdfserial/qcwdfserial.vcxproj
+++ b/src/windows/wdfserial/qcwdfserial.vcxproj
@@ -245,6 +245,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
+	<FilesToPackage Include="$(OutDir)$(TargetName).pdb" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="QCDSP.c" />


### PR DESCRIPTION
### Summary
Add .pdb copy to package in .vxproj build configuration

### Change Description
All drivers:
- After all driver builds completed, copy the .pdb files to the final output package as well
