### PR TITLE
Fix Wdfserial power management checkbox "Allow the computer to turn off this device to save power"

### DIFF
--- a/src/windows/wdfserial/QCMAIN.h
+++ b/src/windows/wdfserial/QCMAIN.h
@@ -261,6 +261,7 @@ typedef struct _DEVICE_CONTEXT
     BOOLEAN                   InServiceSelectiveSuspension;
     ULONG                     SelectiveSuspendIdleTime;
     BOOLEAN                   SelectiveSuspendInMiliSeconds;
+    WDF_POWER_POLICY_S0_IDLE_CAPABILITIES AssignedIdleCaps;
 
     WMILIB_CONTEXT            WmiLibInfo;   // to query system power management tab
     CHAR                      DevSerialNumber[256];  // to hold USB_STRING_DESCRIPTOR of the serial number

--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -2098,7 +2098,6 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
         {
             // registry not set, ss is disabled
             idleSettings.Enabled = WdfFalse;
-            idleSettings.IdleCaps = IdleCannotWakeFromS0;
             status = WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
         }
         else
@@ -2107,6 +2106,7 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
             {
                 idleSettings.IdleTimeout *= 1000;
             }
+            idleSettings.Enabled = WdfTrue;  // explicitly enable SS (overrides any user/registry disable)
             status = WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
             if (status == STATUS_POWER_STATE_INVALID)
             {
@@ -2159,8 +2159,9 @@ NTSTATUS QCPNP_DisableSelectiveSuspend
         ("<%ws> QCPNP_DisableSelectiveSuspend\n", pDevContext->PortName)
     );
 
-    WDF_DEVICE_POWER_POLICY_IDLE_SETTINGS_INIT(&idleSettings, IdleCannotWakeFromS0);
+    WDF_DEVICE_POWER_POLICY_IDLE_SETTINGS_INIT(&idleSettings, IdleUsbSelectiveSuspend);
     idleSettings.Enabled = WdfFalse;
+    idleSettings.UserControlOfIdleSettings = IdleAllowUserControl;
     return WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
 }
 

--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -2098,6 +2098,7 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
         {
             // registry not set, ss is disabled
             idleSettings.Enabled = WdfFalse;
+            idleSettings.IdleCaps = IdleCannotWakeFromS0;
             status = WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
         }
         else
@@ -2129,6 +2130,8 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
         );
     }
 
+    pDevContext->AssignedIdleCaps = idleSettings.IdleCaps;
+
     return status;
 }
 
@@ -2159,7 +2162,12 @@ NTSTATUS QCPNP_DisableSelectiveSuspend
         ("<%ws> QCPNP_DisableSelectiveSuspend\n", pDevContext->PortName)
     );
 
-    WDF_DEVICE_POWER_POLICY_IDLE_SETTINGS_INIT(&idleSettings, IdleUsbSelectiveSuspend);
+    WDF_DEVICE_POWER_POLICY_IDLE_SETTINGS_INIT(
+        &idleSettings,
+        (pDevContext->AssignedIdleCaps != IdleCapsInvalid)
+            ? pDevContext->AssignedIdleCaps
+            : IdleCannotWakeFromS0
+    );
     idleSettings.Enabled = WdfFalse;
     idleSettings.UserControlOfIdleSettings = IdleAllowUserControl;
     return WdfDeviceAssignS0IdleSettings(Device, &idleSettings);


### PR DESCRIPTION
Problem

For qcwdfser devices, unchecking "Allow the computer to turn off this device to save power" sets IdleInWorkingState
= 0 and disables selective suspend. Re-checking the box does not restore IdleInWorkingState = 1 — selective suspend
stays disabled until a manual registry edit and device re-enumeration.

Root Cause Analysis

 1. EnableSelectiveSuspend never sets Enabled = WdfTrue — when called after re-checking the box, WDF sees 
IdleInWorkingState = 0 in the registry and does not re-enable idle, because the driver provides no explicit 
override. This is the direct cause of the bug.
 2. DisableSelectiveSuspend uses a mismatched IdleCaps — it hardcodes IdleCannotWakeFromS0, but WDF locked 
IdleUsbSelectiveSuspend on the first successful enable call. The mismatch causes STATUS_INVALID_DEVICE_REQUEST, so 
the disable call silently fails.
 3. DisableSelectiveSuspend does not set UserControlOfIdleSettings — without IdleAllowUserControl, WDF may ignore 
user-initiated power management toggles.

Solution

 - Set idleSettings.Enabled = WdfTrue explicitly in EnableSelectiveSuspend when SS should be active, forcing WDF to 
restore IdleInWorkingState = 1 regardless of the registry state.
 - Track the accepted IdleCaps in a new DEVICE_CONTEXT field (AssignedIdleCaps), stored after every successful 
WdfDeviceAssignS0IdleSettings call.
 - Use pDevContext->AssignedIdleCaps in DisableSelectiveSuspend instead of a hardcoded value, ensuring the IdleCaps 
always matches what WDF locked — across all code paths (normal, STATUS_POWER_STATE_INVALID fallback, and LPC).
 - Set UserControlOfIdleSettings = IdleAllowUserControl in DisableSelectiveSuspend so user toggles are honored.