### PR TITLE
Fixed QDLoader "fails to open USB Port" issue

### DIFF
--- a/src/linux/RELEASES.md
+++ b/src/linux/RELEASES.md
@@ -23,9 +23,10 @@ Qualcomm USB host drivers providing logical representations of Qualcomm chipset-
 
 ---
 
-## [1.0.6.3] - 2026-05-8
+## [1.0.6.4] - 2026-05-8
 1. First Debian package release of QUD v1.0.6.3 is now available on GitHub. Users can modify the driver source and generate a Debian package using the build-deb.sh script.
-2. Updated the installer script to automatically install kernel headers for the running kernel seamlessly across multiple platforms including Ubuntu, Debian, RHEL, and Fedora.
+2. Updated the installer script to automatically install kernel headers for the running kernel seamlessly across multiple platforms including Ubuntu, Debian, RHEL, and Fedora.[QUD-1881]
+3. Fix DIAG and QDLoader “Could not open connection” issue caused by a subsystem mismatch between driver and udev rules [QUD-1880], [QUD-1882]
 
 ## [1.0.6.1] - 2026-04-6
 1. Support newer kernel version 6.15, 6.16 and 6.17 for Ubuntu 24.

--- a/src/linux/qcom_usb/qcom_usb.h
+++ b/src/linux/qcom_usb/qcom_usb.h
@@ -73,8 +73,8 @@
 #define QTIDEV_RX_NOTIFY_POOL_SZ 32
 #define QTIDEV_TX_BUF_POOL_SZ    32
 #define QTIDEV_DRIVER_NAME       "QCOM_QDSS_DPL_DIAG_Subsystem"
-#define QTIDEV_USB_CLASS_NAME    "GobiUSB"
-#define QTIDEV_PORT_CLASS_NAME   "GobiPorts"
+#define QTIDEV_USB_CLASS_NAME    "qcom_usb"
+#define QTIDEV_PORT_CLASS_NAME   "qcom_ports"
 //#define QTIDEV_SERIAL_CLASS_NAME   "GobiSerial"
 
 #define BULK_URB_INITIALIZED    (1 << 0)

--- a/src/linux/version.h
+++ b/src/linux/version.h
@@ -5,5 +5,5 @@
 
 #ifndef VERSION_H
 #define VERSION_H
-#define DRIVER_VERSION "1.0.6.3"
+#define DRIVER_VERSION "1.0.6.4"
 #endif


### PR DESCRIPTION
A few customers reported that when the device enters EDL mode, they are unable to perform a build download via PCAT using the QDLoader interface exposed by the QUD linux driver.

We have now identified and resolved the issue.
The root cause was a permission problem affecting the DIAG and QDLoader interfaces, caused by a subsystem mismatch between the driver implementation and the udev rules.

