### PR TITLE
Added scripts and projects to create self-extracting installer on Windows

### DIFF
--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,0 +1,453 @@
+param(
+    [string]$PayloadPath,
+    [string]$OutputPath
+)
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+
+$Script:OutputRoot   = Join-Path $PSScriptRoot "target"
+$Script:DriversDir   = "Drivers"
+$Script:ToolsDir     = "Tools"
+$Script:PayloadName  = "payload.zip"
+$Script:VersionFile  = Join-Path $PSScriptRoot "..\src\windows\qcversion.h"
+
+# Files to promote from Tools/ to the payload root (alongside Drivers/ and Tools/)
+$Script:PromotedTools = @("qdclr.exe", "qdinstall.exe")
+
+# ==============================================================================
+# Functions
+# ==============================================================================
+
+# Assembles a payload zip from target/Drivers and target/Tools.
+# Promoted tools (qdclr.exe, qdinstall.exe) are copied to the zip root.
+# Returns the full path to the generated payload zip.
+# Payload layout contract (must match expectations in the embedded C# installer):
+#   <zip root>/
+#     qdinstall.exe   <- promoted from Tools/; used as entry point by C# installer
+#     qdclr.exe       <- promoted from Tools/; used by qdinstall.exe -x
+#     Drivers/        <- INF files passed to pnputil
+#     Tools/          <- remaining tools copied to installPath
+function New-Payload {
+    Write-Host "========================================"
+    Write-Host " Packaging Payload"
+    Write-Host "========================================`n"
+
+    $driversSource = Join-Path $Script:OutputRoot $Script:DriversDir
+    $toolsSource   = Join-Path $Script:OutputRoot $Script:ToolsDir
+
+    if (-not (Test-Path $driversSource)) {
+        Write-Error "Drivers directory not found: $driversSource"
+        exit 1
+    }
+    if (-not (Test-Path $toolsSource)) {
+        Write-Error "Tools directory not found: $toolsSource"
+        exit 1
+    }
+
+    # Create a temp staging directory
+    $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) ([Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
+
+    try {
+        # Copy Drivers/
+        $destDrivers = Join-Path $stagingDir $Script:DriversDir
+        Copy-Item -Path $driversSource -Destination $destDrivers -Recurse -Force
+        Write-Host "[COPY] $Script:DriversDir -> $destDrivers"
+
+        # Copy Tools/
+        $destTools = Join-Path $stagingDir $Script:ToolsDir
+        Copy-Item -Path $toolsSource -Destination $destTools -Recurse -Force
+        Write-Host "[COPY] $Script:ToolsDir -> $destTools"
+
+        # Promote specified tools to staging root and remove from Tools/
+        foreach ($toolFile in $Script:PromotedTools) {
+            $srcFile = Join-Path $destTools $toolFile
+            if (Test-Path $srcFile) {
+                Copy-Item -Path $srcFile -Destination $stagingDir -Force
+                Remove-Item -Path $srcFile -Force
+                Write-Host "[PROMOTE] $toolFile -> payload root"
+            } else {
+                Write-Warning "Promoted tool not found in Tools: $toolFile"
+            }
+        }
+
+        # Create the zip
+        $payloadZip = Join-Path $Script:OutputRoot $Script:PayloadName
+        if (Test-Path $payloadZip) {
+            Remove-Item $payloadZip -Force
+        }
+
+        Write-Host "[ZIP] Creating: $payloadZip"
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $payloadZip)
+
+        $zipSize = (Get-Item $payloadZip).Length
+        Write-Host "[OK] Payload created: $payloadZip ($zipSize bytes)`n" -ForegroundColor Green
+
+        return $payloadZip
+    }
+    finally {
+        # Clean up staging directory
+        if (Test-Path $stagingDir) {
+            Remove-Item $stagingDir -Recurse -Force
+        }
+    }
+}
+
+# ==============================================================================
+# Main Logic
+# ==============================================================================
+
+# --- Resolve payload ---
+if (-not $PayloadPath) {
+    $PayloadPath = New-Payload
+}
+
+if (-not (Test-Path $PayloadPath)) {
+    Write-Error "Payload file not found: $PayloadPath"
+    exit 1
+}
+
+$PayloadFullPath = (Resolve-Path $PayloadPath).Path
+
+# --- Parse version ---
+$Version = "1.0.0.0"
+if (Test-Path $Script:VersionFile) {
+    $versionContent = Get-Content $Script:VersionFile -Raw
+    if ($versionContent -match '#define\s+QCOM_USB_DRIVERS_PRODUCT_VERSION\s+([\d.]+)') {
+        $Version = $Matches[1]
+        Write-Host "[INFO] Version from header: $Version"
+    } else {
+        Write-Warning "QCOM_USB_DRIVERS_PRODUCT_VERSION not found in $($Script:VersionFile), using default: $Version"
+    }
+} else {
+    Write-Warning "Version file not found: $($Script:VersionFile), using default: $Version"
+}
+
+# C# source code for the installer
+$csharpSource = @'
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using Microsoft.Win32;
+
+[assembly: AssemblyTitle("Qualcomm USB Driver Installer")]
+[assembly: AssemblyDescription("Qualcomm USB Driver Installer")]
+[assembly: AssemblyCompany("Qualcomm Technologies, Inc.")]
+[assembly: AssemblyProduct("Qualcomm USB Kernel Drivers")]
+[assembly: AssemblyCopyright("Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.")]
+[assembly: AssemblyVersion("__VERSION__")]
+[assembly: AssemblyFileVersion("__VERSION__")]
+[assembly: AssemblyInformationalVersion("__VERSION__")]
+
+namespace PayloadInstaller
+{
+    class Program
+    {
+        static readonly string UninstallRegKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Qualcomm USB Drivers";
+
+        static string[] packages = {
+            "qualcomm_userspace_driver",
+            "qud",
+            "qud.slt",
+            "qud.internal"
+        };
+
+        static void CopyDirectory(string sourceDir, string destDir)
+        {
+            Directory.CreateDirectory(destDir);
+            foreach (string file in Directory.GetFiles(sourceDir))
+            {
+                string destFile = Path.Combine(destDir, Path.GetFileName(file));
+                File.Copy(file, destFile, true);
+            }
+            foreach (string dir in Directory.GetDirectories(sourceDir))
+            {
+                string destSubDir = Path.Combine(destDir, Path.GetFileName(dir));
+                CopyDirectory(dir, destSubDir);
+            }
+        }
+
+        static int ElevateIfNeeded(string[] args)
+        {
+            var principal = new System.Security.Principal.WindowsPrincipal(
+                System.Security.Principal.WindowsIdentity.GetCurrent());
+            if (principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator))
+                return -1; // Already running as admin
+
+            ProcessStartInfo elevate = new ProcessStartInfo();
+            elevate.FileName = Assembly.GetExecutingAssembly().Location;
+            elevate.Arguments = string.Join(" ", args);
+            elevate.UseShellExecute = true;
+            elevate.Verb = "runas";
+            try
+            {
+                Process proc = Process.Start(elevate);
+                proc.WaitForExit();
+                return proc.ExitCode;
+            }
+            catch (Exception)
+            {
+                Console.Error.WriteLine("Error: Administrator privileges required.");
+                return 1;
+            }
+        }
+
+        static int RunCommand(string fileName, string arguments)
+        {
+            try
+            {
+                ProcessStartInfo psi = new ProcessStartInfo();
+                psi.FileName = fileName;
+                if (arguments != null)
+                    psi.Arguments = arguments;
+                psi.UseShellExecute = false;
+                Process proc = Process.Start(psi);
+                proc.WaitForExit();
+                return proc.ExitCode;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("Warning: Failed to run " + fileName + ": " + ex.Message);
+                return -1;
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            // Parse arguments
+            string mode = "install"; // default (no args)
+
+            if (args.Length > 0)
+            {
+                string arg = args[0];
+                if (arg == "-i" || arg == "--install" || arg == "/install")
+                    mode = "install";
+                else if (arg == "-u" || arg == "--uninstall" || arg == "/uninstall")
+                    mode = "uninstall";
+                else if (arg == "-v" || arg == "--version" || arg == "/version")
+                    mode = "version";
+                else
+                {
+                    Console.Error.WriteLine("Error: Invalid argument: " + arg);
+                    Console.Error.WriteLine("Usage: QUD_Installer.exe [option]");
+                    Console.Error.WriteLine("  -i, --install    Install drivers (default)");
+                    Console.Error.WriteLine("  -u, --uninstall  Uninstall drivers");
+                    Console.Error.WriteLine("  -v, --version    Show version");
+                    return 1;
+                }
+            }
+
+            if (mode == "version")
+            {
+                Console.WriteLine("Package version: __VERSION__");
+                return 0;
+            }
+
+            // Self-elevate if not running as administrator
+            int elevateResult = ElevateIfNeeded(args);
+            if (elevateResult >= 0)
+                return elevateResult;
+
+            if (mode == "uninstall")
+            {
+                // Read install location from registry
+                string uninstallPath = null;
+                using (var key = Registry.LocalMachine.OpenSubKey(UninstallRegKey))
+                {
+                    if (key != null)
+                        uninstallPath = key.GetValue("InstallLocation") as string;
+                }
+
+                if (string.IsNullOrEmpty(uninstallPath))
+                {
+                    Console.Error.WriteLine("Error: Cannot find installation from registry.");
+                    return 1;
+                }
+
+                // Run qdinstall.exe -x from the install location
+                string qdinstallExe = Path.Combine(uninstallPath, "qdinstall.exe");
+                Console.WriteLine("Running uninstaller: " + qdinstallExe);
+                int result = RunCommand(qdinstallExe, "-x");
+
+                // Delete install directory on success
+                if (result == 0 && !string.IsNullOrEmpty(uninstallPath) && Directory.Exists(uninstallPath))
+                {
+                    Directory.Delete(uninstallPath, true);
+                    Console.WriteLine("Deleted install directory: " + uninstallPath);
+                    Console.WriteLine("\nUninstall completed successfully.");
+                }
+                else if (result != 0)
+                {
+                    Console.Error.WriteLine("\nUninstall failed with exit code: " + result);
+                }
+                return result;
+            }
+
+            // Install mode
+            string installPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                "Qualcomm", "Qualcomm USB Drivers");
+
+            if (!Directory.Exists(installPath))
+                Directory.CreateDirectory(installPath);
+
+            // Extract embedded payload to temp directory
+            string tempDir = null;
+            try
+            {
+                tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("B").ToUpper());
+                string tempZip = Path.Combine(tempDir, "payload.zip");
+
+                Console.WriteLine("Extracting payload to: " + tempDir);
+
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                using (Stream resourceStream = assembly.GetManifestResourceStream("Payload.zip"))
+                {
+                    if (resourceStream == null)
+                    {
+                        Console.Error.WriteLine("Error: Embedded payload resource not found.");
+                        return 1;
+                    }
+
+                    Directory.CreateDirectory(tempDir);
+                    using (FileStream fileStream = new FileStream(tempZip, FileMode.Create, FileAccess.Write))
+                    {
+                        resourceStream.CopyTo(fileStream);
+                    }
+                }
+
+                ZipFile.ExtractToDirectory(tempZip, tempDir);
+                File.Delete(tempZip);
+                Console.WriteLine("Extraction complete.");
+
+                // Uninstall legacy packages first (silent to avoid interactive UI)
+                foreach (string pkg in packages)
+                {
+                    Console.WriteLine("\nUninstalling legacy product: " + pkg + "...");
+                    RunCommand("qpm-cli", "--uninstall " + pkg + " --silent");
+                }
+
+                // Copy files to install path BEFORE registering, so that if the
+                // copy fails the registry is never written and no rollback is needed.
+                Console.WriteLine("Copying files to: " + installPath);
+                try { Directory.Delete(installPath, true); } catch { }
+                Directory.CreateDirectory(installPath);
+                CopyDirectory(tempDir, installPath);
+
+                // Verify qdinstall.exe is present in the payload root
+                // (see payload layout contract in build-installer.ps1: New-Payload)
+                string qdinstallPath = Path.Combine(tempDir, "qdinstall.exe");
+                if (!File.Exists(qdinstallPath))
+                {
+                    Console.Error.WriteLine("Error: qdinstall.exe not found in payload root.");
+                    Console.Error.WriteLine("       Expected at: " + qdinstallPath);
+                    return 1;
+                }
+
+                // Run qdinstall to register the installation (files are now in place)
+                Console.WriteLine("\nRunning installer...");
+                int result = RunCommand(qdinstallPath, "-i -p \"" + installPath + "\"");
+
+                if (result == 0)
+                {
+                    Console.WriteLine("\nInstall completed successfully.");
+                }
+                else
+                {
+                    Console.Error.WriteLine("\nInstall failed with exit code: " + result);
+                    // Rollback: remove install directory since registration failed
+                    try { Directory.Delete(installPath, true); }
+                    catch (Exception ex) { Console.Error.WriteLine("Warning: rollback failed: " + ex.Message); }
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("Error: " + ex.Message);
+                return 1;
+            }
+            finally
+            {
+                if (tempDir != null && Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+    }
+}
+'@
+
+# --- Resolve output exe path ---
+$DefaultExeName = "QUD_Installer.exe"
+if (-not $OutputPath) {
+    $outputExe = Join-Path $PSScriptRoot $DefaultExeName
+} elseif (Test-Path $OutputPath -PathType Container) {
+    $outputExe = Join-Path $OutputPath $DefaultExeName
+} elseif ($OutputPath -match '\.[^\\\/]+$') {
+    # Has extension - treat as full file path
+    $outputExe = $OutputPath
+    $outputDir = Split-Path $outputExe -Parent
+    if ($outputDir -and -not (Test-Path $outputDir)) {
+        New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+    }
+} else {
+    # No extension - treat as directory
+    if (-not (Test-Path $OutputPath)) {
+        New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+    }
+    $outputExe = Join-Path $OutputPath $DefaultExeName
+}
+
+# Write C# source to a temp file in the system temp directory
+$sourceFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.cs')
+
+$csharpSource = $csharpSource.Replace("__VERSION__", $Version)
+Set-Content -Path $sourceFile -Value $csharpSource -Encoding UTF8
+
+# Locate csc.exe: probe Framework64 first, then Framework, then PATH
+$cscPath = $null
+foreach ($ver in @("v4.0.30319")) {
+    $candidate = "C:\Windows\Microsoft.NET\Framework64\$ver\csc.exe"
+    if (Test-Path $candidate) { $cscPath = $candidate; break }
+    $candidate = "C:\Windows\Microsoft.NET\Framework\$ver\csc.exe"
+    if (Test-Path $candidate) { $cscPath = $candidate; break }
+}
+if (-not $cscPath) {
+    $cscCmd = Get-Command "csc.exe" -ErrorAction SilentlyContinue
+    if ($cscCmd) { $cscPath = $cscCmd.Source }
+}
+if (-not $cscPath) {
+    Write-Error "csc.exe not found. Please install .NET Framework 4.x."
+    exit 1
+}
+
+# Build the installer
+Write-Host "Building installer..."
+Write-Host "  Payload: $PayloadFullPath"
+Write-Host "  Output:  $outputExe"
+
+$cscArgs = @(
+    "/target:exe",
+    "/out:$outputExe",
+    "/resource:$PayloadFullPath,Payload.zip",
+    "/reference:System.IO.Compression.dll",
+    "/reference:System.IO.Compression.FileSystem.dll",
+    $sourceFile
+)
+
+& $cscPath $cscArgs
+
+$buildExitCode = $LASTEXITCODE
+if (Test-Path $sourceFile) { Remove-Item $sourceFile -Force }
+if ($buildExitCode -eq 0) {
+    Write-Host "Build successful: $outputExe" -ForegroundColor Green
+} else {
+    Write-Error "Build failed with exit code: $buildExitCode"
+    exit $buildExitCode
+}

--- a/build/build_drivers.bat
+++ b/build/build_drivers.bat
@@ -4,7 +4,7 @@ setlocal
 set "SCRIPT_DIR=%~dp0"
 set "BUILD_ROOT=%SCRIPT_DIR%\target"
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\build.ps1" -OutputTo "%BUILD_ROOT%"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\build_drivers.ps1" -OutputTo "%BUILD_ROOT%"
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\sign.ps1" -InputFrom "%BUILD_ROOT%"

--- a/build/build_drivers.ps1
+++ b/build/build_drivers.ps1
@@ -12,7 +12,7 @@ $Script:VSWhereExe = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\v
 
 $Script:SourceRoot = "..\src\windows"  # Windows source directory, update when build folder moves
 $Script:OutputRoot = "target" # Directory for all output by default, use -OutputTo to override
-$Script:OutputSubDir = "Drivers\Windows10"
+$Script:DriversDir = "Drivers\Windows10"
 
 # Build configuration defaults
 $Script:BuildConfiguration = "Release"
@@ -571,7 +571,7 @@ function Main {
     else {
         $Script:OutputRoot = Resolve-ScriptPath $OutputRoot
     }
-    $Script:OutputRoot = Join-Path $OutputRoot $OutputSubDir
+    $Script:OutputRoot = Join-Path $OutputRoot $DriversDir
     $Script:VersionHeaderFile = Resolve-ScriptPath $Script:VersionHeaderFile
 
     # --- Step 1: Locate MSBuild ---

--- a/build/build_installer.bat
+++ b/build/build_installer.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "SCRIPT_DIR=%~dp0"
+
+for %%A in (x86 x64 arm64) do (
+    echo ========================================
+    echo  Building for %%A
+    echo ========================================
+
+    REM Build tools for this architecture
+    powershell -ExecutionPolicy Bypass -File "%SCRIPT_DIR%build_tools.ps1" -Platform %%A
+    if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!
+
+    REM Build installer with arch-specific output name
+    powershell -ExecutionPolicy Bypass -File "%SCRIPT_DIR%build-installer.ps1" -OutputPath "%SCRIPT_DIR%target\qcom_usb_kernel_drivers_%%A.exe"
+    if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!
+
+    REM Sign the installer
+    powershell -ExecutionPolicy Bypass -File "%SCRIPT_DIR%sign.ps1" -InputFrom "%SCRIPT_DIR%target\qcom_usb_kernel_drivers_%%A.exe"
+    if !ERRORLEVEL! neq 0 (
+        echo [WARN] Signing failed for %%A. The unsigned exe is still available.
+    )
+
+    echo [DONE] %SCRIPT_DIR%target\qcom_usb_kernel_drivers_%%A.exe
+    echo.
+)
+
+echo ========================================
+echo  All installers built.
+echo ========================================
+
+endlocal
+exit /b 0

--- a/build/build_tools.ps1
+++ b/build/build_tools.ps1
@@ -1,0 +1,257 @@
+#Requires -Version 5.0
+
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet("x86", "x64", "arm64")]
+    [string]$Platform,
+    [string]$OutputTo
+)
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+
+$Script:VSWhereExe = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+
+$Script:SourceRoot = "..\src\windows"  # Windows source directory, update when build folder moves
+$Script:OutputRoot = "target"           # Directory for all output by default
+$Script:ToolsDir   = "Tools"
+
+# Build configuration
+$Script:BuildConfiguration = "Release"
+
+# Platform mappings: input platform -> MSBuild platform name, output subdirectory template
+# OutDir uses {0} as placeholder for the configuration name (e.g., "Release", "Release_EXE")
+$Script:PlatformMap = @{
+    "x86"   = @{ MSBuild = "x86";   OutDir = "{0}" }
+    "x64"   = @{ MSBuild = "x64";   OutDir = "x64\{0}" }
+    "arm64" = @{ MSBuild = "ARM64"; OutDir = "ARM64\{0}" }
+}
+
+# Tool project definitions
+# - Name:               Display name
+# - SolutionPath:       Path to .sln file (relative to script root)
+# - Configuration:      (Optional) MSBuild configuration; defaults to $BuildConfiguration
+# - SupportedPlatforms: Platforms the project can build for
+# - OutputFiles:        Files to copy from build output to ToolsDir
+$Script:ToolProjects = @(
+    @{
+        Name               = "qcdev"
+        SolutionPath       = "$SourceRoot\tools\qcdev\qcdev.sln"
+        SupportedPlatforms = @("x86")
+        OutputFiles        = @("qcdev.dll")
+    }
+    @{
+        Name               = "qdcfg"
+        SolutionPath       = "$SourceRoot\tools\qdcfg\qdcfg.sln"
+        Configuration      = "Release"
+        SupportedPlatforms = @("x86")
+        OutputFiles        = @("qdcfg.dll")
+    }
+    @{
+        Name               = "qdcfg_exe"
+        SolutionPath       = "$SourceRoot\tools\qdcfg\qdcfg.sln"
+        Configuration      = "Release_EXE"
+        SupportedPlatforms = @("x86")
+        OutputFiles        = @("qdcfg.exe")
+    }
+    @{
+        Name               = "qdclr"
+        SolutionPath       = "$SourceRoot\tools\qdclr\qdclr.sln"
+        SupportedPlatforms = @("x86", "x64", "arm64")
+        OutputFiles        = @("qdclr.exe")
+    }
+    @{
+        Name               = "qdinstall"
+        SolutionPath       = "$SourceRoot\tools\qdinstall\qdinstall.sln"
+        SupportedPlatforms = @("x86", "x64", "arm64")
+        OutputFiles        = @("qdinstall.exe")
+    }
+    @{
+        Name               = "wwansvc"
+        SolutionPath       = "$SourceRoot\tools\wwansvc\qcmtusvc.sln"
+        SupportedPlatforms = @("x86")
+        OutputFiles        = @("qcmtusvc.exe")
+    }
+)
+
+# MSBuild path (auto-detect at runtime)
+$Script:MSBuildExe = $null
+
+# ==============================================================================
+# Functions
+# ==============================================================================
+
+# Resolves a path to an absolute path relative to the script directory.
+function Resolve-ScriptPath {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not [System.IO.Path]::IsPathRooted($Path)) {
+        $Path = Join-Path $PSScriptRoot $Path
+    }
+    return $Path
+}
+
+# Locates MSBuild.exe on the system via PATH or vswhere.exe fallback.
+function Find-MSBuild {
+    $msbuildCmd = Get-Command "msbuild.exe" -ErrorAction SilentlyContinue
+    if ($msbuildCmd) {
+        Write-Host "[INFO] Found MSBuild on PATH: $($msbuildCmd.Source)"
+        return $msbuildCmd.Source
+    }
+
+    Write-Host "[INFO] MSBuild not found on PATH. Trying vswhere.exe..."
+
+    if (-not (Test-Path $VSWhereExe)) {
+        Write-Host "[WARN] vswhere.exe not found at: $VSWhereExe" -ForegroundColor Yellow
+        return $null
+    }
+
+    $vsInstallPath = & $VSWhereExe -latest -products * -requires Microsoft.Component.MSBuild -property installationPath 2>$null
+    if (-not $vsInstallPath) {
+        Write-Host "[WARN] vswhere.exe could not find a Visual Studio installation with MSBuild." -ForegroundColor Yellow
+        return $null
+    }
+
+    Write-Host "[INFO] Visual Studio installation found at: $vsInstallPath"
+
+    $msbuildPath = Join-Path $vsInstallPath "MSBuild\Current\Bin\MSBuild.exe"
+    if (Test-Path $msbuildPath) {
+        Write-Host "[INFO] Found MSBuild via vswhere: $msbuildPath"
+        return $msbuildPath
+    }
+
+    Write-Host "[WARN] MSBuild.exe not found under Visual Studio installation: $vsInstallPath" -ForegroundColor Yellow
+    return $null
+}
+
+# Builds a single project with MSBuild for a given platform and configuration.
+function Build-Project {
+    param(
+        [Parameter(Mandatory)][string]$SolutionPath,
+        [Parameter(Mandatory)][string]$Configuration,
+        [Parameter(Mandatory)][string]$MSBuildPlatform
+    )
+
+    $SolutionPath = Resolve-ScriptPath $SolutionPath
+    if (-not (Test-Path $SolutionPath)) {
+        Write-Host "[ERROR] Solution not found: $SolutionPath" -ForegroundColor Red
+        return $false
+    }
+
+    $slnName = [System.IO.Path]::GetFileName($SolutionPath)
+    Write-Host "[BUILD] $slnName | $Configuration | $MSBuildPlatform"
+    & $MSBuildExe $SolutionPath `
+        /p:Configuration=$Configuration `
+        /p:Platform=$MSBuildPlatform `
+        /t:Build `
+        /m `
+        /nologo `
+        /verbosity:minimal | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[ERROR] Build failed: $slnName ($MSBuildPlatform)" -ForegroundColor Red
+        Write-Host "[ERROR] MSBuild exit code: $LASTEXITCODE" -ForegroundColor Red
+        return $false
+    }
+
+    Write-Host "[OK] $slnName ($MSBuildPlatform) built successfully.`n" -ForegroundColor Green
+    return $true
+}
+
+# ==============================================================================
+# Main
+# ==============================================================================
+
+function Main {
+    Write-Host "========================================"
+    Write-Host " QCOM USB Tools - Build Script"
+    Write-Host " Platform: $Platform"
+    Write-Host "========================================`n"
+
+    # --- Resolve output directory ---
+    if ($OutputTo) {
+        $Script:OutputRoot = $OutputTo
+    }
+    else {
+        $Script:OutputRoot = Resolve-ScriptPath $OutputRoot
+    }
+    $toolsOutputDir = Join-Path $OutputRoot $ToolsDir
+
+    # --- Locate MSBuild ---
+    $Script:MSBuildExe = Find-MSBuild
+    if (-not $MSBuildExe) {
+        Write-Host "[ERROR] MSBuild.exe could not be found." -ForegroundColor Red
+        Write-Host "[ERROR] Please ensure Visual Studio with C++ build tools is installed." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "[OK] MSBuild is available at: $MSBuildExe" -ForegroundColor Green
+    Write-Host ""
+
+    # --- Create output directory ---
+    if (-not (Test-Path $toolsOutputDir)) {
+        New-Item -ItemType Directory -Path $toolsOutputDir -Force | Out-Null
+    }
+
+    # --- Build and copy each tool ---
+    Write-Host "========================================"
+    Write-Host " Building Tools"
+    Write-Host "========================================`n"
+
+    $successCount = 0
+
+    foreach ($tool in $ToolProjects) {
+        Write-Host "--- $($tool.Name) ---" -ForegroundColor Cyan
+
+        # Determine actual build platform (fallback to x86 if unsupported)
+        $actualPlatform = $Platform
+        if ($tool.SupportedPlatforms -notcontains $Platform) {
+            Write-Host "[WARN] $($tool.Name) does not support '$Platform'. Falling back to 'x86'." -ForegroundColor Yellow
+            $actualPlatform = "x86"
+        }
+
+        $platformInfo = $PlatformMap[$actualPlatform]
+
+        # Determine build configuration (per-project override or global default)
+        $configuration = if ($tool.Configuration) { $tool.Configuration } else { $BuildConfiguration }
+
+        # Build
+        if (-not (Build-Project `
+            -SolutionPath $tool.SolutionPath `
+            -Configuration $configuration `
+            -MSBuildPlatform $platformInfo.MSBuild)) {
+            Write-Host "[ERROR] Aborting." -ForegroundColor Red
+            exit 1
+        }
+
+        # Resolve output directory for the built project
+        $projectDir = Resolve-ScriptPath (Split-Path $tool.SolutionPath -Parent)
+        $outDirRelative = $platformInfo.OutDir -f $configuration
+        $buildOutputDir = Join-Path $projectDir $outDirRelative
+
+        # Copy specified output files
+        foreach ($fileName in $tool.OutputFiles) {
+            $srcFile = Join-Path $buildOutputDir $fileName
+            if (-not (Test-Path $srcFile)) {
+                Write-Host "[ERROR] Expected output not found: $srcFile" -ForegroundColor Red
+                exit 1
+            }
+
+            Copy-Item -Path $srcFile -Destination $toolsOutputDir -Force
+            Write-Host "[COPY] $fileName -> $toolsOutputDir"
+        }
+
+        $successCount++
+        Write-Host ""
+    }
+
+    # --- Summary ---
+    Write-Host "========================================"
+    Write-Host " Summary"
+    Write-Host "========================================`n"
+
+    Write-Host "[OK] $successCount/$($ToolProjects.Count) tool(s) built successfully." -ForegroundColor Green
+    Write-Host "[INFO] Output: $toolsOutputDir"
+    Write-Host ""
+}
+
+Main

--- a/src/windows/qcversion.h
+++ b/src/windows/qcversion.h
@@ -3,8 +3,13 @@
 
 #define STRINGIFY(s) #s
 #define QCSTR(str) STRINGIFY(str)
-#define QCOM_USB_DRIVERS_PRODUCT_VERSION 1.00.94.2
+#define WSTRINGIFY(s) L#s
+#define QCWSTR(str) WSTRINGIFY(str)
+
+#define QCOM_USB_DRIVERS_PRODUCT_VERSION 1.00.94.3
+#define QCOM_USB_DRIVERS_FILE_VERSION 1,00,94,3
 #define QCOM_USB_DRIVERS_PRODUCT_VERSION_STRING QCSTR(QCOM_USB_DRIVERS_PRODUCT_VERSION)
+#define QCOM_USB_DRIVERS_PRODUCT_VERSION_STRING_W QCWSTR(QCOM_USB_DRIVERS_PRODUCT_VERSION)
 
 #define QCOM_FILTER_VERSION 1.0.1.4
 #define QCOM_FILTER_FILE_VERSION 1,0,1,4
@@ -25,5 +30,10 @@
 #define QCOM_ADB_VERSION 1.0.1.6
 
 #define QCOM_USB_DRIVERS_COMPANY_NAME "Qualcomm Technologies, Inc."
+#define QCOM_USB_DRIVERS_COMPANY_NAME_W L"Qualcomm Technologies, Inc."
+
 #define QCOM_USB_DRIVERS_PRODUCT_NAME "Qualcomm USB Kernel Drivers"
+#define QCOM_USB_DRIVERS_PRODUCT_NAME_W L"Qualcomm USB Kernel Drivers"
+
 #define QCOM_USB_DRIVERS_COPYRIGHT "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries."
+#define QCOM_USB_DRIVERS_COPYRIGHT_W L"Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries."

--- a/src/windows/tools/qcdev/qcdev.sln
+++ b/src/windows/tools/qcdev/qcdev.sln
@@ -6,15 +6,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qcdev", "qcdev.vcxproj", "{
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
-		Release|Win32 = Release|Win32
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Debug|Win32.ActiveCfg = Debug|Win32
-		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Debug|Win32.Build.0 = Debug|Win32
-		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Release|Win32.ActiveCfg = Release|Win32
-		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Release|Win32.Build.0 = Release|Win32
-		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Release|Win32.Deploy.0 = Release|Win32
+		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Debug|x86.ActiveCfg = Debug|Win32
+		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Debug|x86.Build.0 = Debug|Win32
+		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Release|x86.ActiveCfg = Release|Win32
+		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Release|x86.Build.0 = Release|Win32
+		{351DA988-07E9-4A1B-9ADC-5DECFE5493C6}.Release|x86.Deploy.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/windows/tools/qdcfg/qdcfg.sln
+++ b/src/windows/tools/qdcfg/qdcfg.sln
@@ -6,21 +6,21 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qdcfg", "qdcfg.vcxproj", "{
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug_EXE|Win32 = Debug_EXE|Win32
-		Debug|Win32 = Debug|Win32
-		Release_EXE|Win32 = Release_EXE|Win32
-		Release|Win32 = Release|Win32
+		Debug_EXE|x86 = Debug_EXE|x86
+		Debug|x86 = Debug|x86
+		Release_EXE|x86 = Release_EXE|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug_EXE|Win32.ActiveCfg = Debug_EXE|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug_EXE|Win32.Build.0 = Debug_EXE|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug|Win32.ActiveCfg = Debug|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug|Win32.Build.0 = Debug|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release_EXE|Win32.ActiveCfg = Release_EXE|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release_EXE|Win32.Build.0 = Release_EXE|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release|Win32.ActiveCfg = Release|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release|Win32.Build.0 = Release|Win32
-		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release|Win32.Deploy.0 = Release|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug_EXE|x86.ActiveCfg = Debug_EXE|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug_EXE|x86.Build.0 = Debug_EXE|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug|x86.ActiveCfg = Debug|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Debug|x86.Build.0 = Debug|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release_EXE|x86.ActiveCfg = Release_EXE|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release_EXE|x86.Build.0 = Release_EXE|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release|x86.ActiveCfg = Release|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release|x86.Build.0 = Release|Win32
+		{9130613B-D0F3-E81D-DD33-A6DF52E015FC}.Release|x86.Deploy.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/windows/tools/qdinstall/main.cpp
+++ b/src/windows/tools/qdinstall/main.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "main.h"
+#include "registry.h"
+#include "../../qcversion.h"
+
+constexpr const wchar_t *COMMAND_QDCLR = L"qdclr.exe";
+#ifdef _WIN64
+constexpr const wchar_t *COMMAND_PNPUTIL_MAIN = L"pnputil /add-driver \"";
+#else
+constexpr const wchar_t *COMMAND_PNPUTIL_MAIN = L"C:\\Windows\\Sysnative\\pnputil.exe /add-driver \"";
+#endif
+constexpr const wchar_t *COMMAND_PNPUTIL_OPTS = L"\" /install /force";
+constexpr const wchar_t *PATH_INF_DIR         = L".\\Drivers\\Windows10\\";
+
+DWORD scan_for_hardware_changes()
+{
+    DEVINST dev_root = 0;
+    CONFIGRET cr = CM_Locate_DevNode(&dev_root, NULL, CM_LOCATE_DEVNODE_NORMAL);
+
+    if (cr != CR_SUCCESS)
+    {
+        printf("ERROR: CM_Locate_DevNode failed (CR=0x%X)\n", cr);
+        return ERROR_DEVICE_ENUMERATION_ERROR;
+    }
+
+    cr = CM_Reenumerate_DevNode(dev_root, 0);
+    if (cr != CR_SUCCESS)
+    {
+        printf("ERROR: CM_Reenumerate_DevNode failed (CR=0x%X)\n", cr);
+        return ERROR_DEVICE_ENUMERATION_ERROR;
+    }
+
+    return ERROR_SUCCESS;
+}
+
+DWORD execute_command(const std::wstring &command)
+{
+    PROCESS_INFORMATION pi = {};
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+    DWORD ret = ERROR_SUCCESS;
+
+    if (!CreateProcessW(nullptr, const_cast<wchar_t *>(command.c_str()), nullptr,
+                        nullptr, FALSE, 0, nullptr, nullptr, &si, &pi))
+    {
+        ret = GetLastError();
+    }
+    else
+    {
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        GetExitCodeProcess(pi.hProcess, &ret);
+
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    }
+
+    return ret;
+}
+
+DWORD install_drivers()
+{
+    // Clean old drivers (best effort — ignore errors from qdclr)
+    printf("\nRemoving old drivers ...\n");
+    execute_command(COMMAND_QDCLR);
+
+    // Find and install each .inf in current directory
+    DWORD ret = ERROR_SUCCESS;
+    WIN32_FIND_DATAW fd;
+    std::wstring search_pattern = std::wstring(PATH_INF_DIR) + L".\\*.inf";
+    HANDLE hFind = FindFirstFileW(search_pattern.c_str(), &fd);
+
+    if (hFind == INVALID_HANDLE_VALUE)
+    {
+        printf("WARNING: no .inf files found in %ws\n", PATH_INF_DIR);
+        return ERROR_FILE_NOT_FOUND;
+    }
+
+    do {
+        std::wstring cmd = COMMAND_PNPUTIL_MAIN;
+        cmd += PATH_INF_DIR;
+        cmd += fd.cFileName;
+        cmd += COMMAND_PNPUTIL_OPTS;
+        printf("\nInstalling %ws ...\n", fd.cFileName);
+        if ((ret = execute_command(cmd)) != ERROR_SUCCESS)
+        {
+            printf("ERROR: pnputil failed for %ws (exit code 0x%lX)\n", fd.cFileName, ret);
+            FindClose(hFind);
+            return ret;
+        }
+    } while (FindNextFileW(hFind, &fd));
+
+    FindClose(hFind);
+    return scan_for_hardware_changes();
+}
+
+DWORD uninstall_drivers()
+{
+    printf("Removing drivers ...\n");
+    DWORD ret = execute_command(COMMAND_QDCLR);
+
+    if (ret == ERROR_FILE_NOT_FOUND)
+    {
+        printf("ERROR: qdclr.exe not found in current directory\n");
+    }
+    else if (ret == ERROR_ACCESS_DENIED)
+    {
+        printf("ERROR: qdclr.exe cannot be opened\n");
+    }
+    else if (ret == ERROR_SUCCESS)
+    {
+        ret = scan_for_hardware_changes();
+    }
+    else
+    {
+        printf("ERROR: qdclr.exe failed (exit code 0x%lX)\n", ret);
+    }
+
+    return ret;
+}
+
+static std::wstring get_exe_directory()
+{
+    std::wstring path(MAX_PATH, L'\0');
+    DWORD len = GetModuleFileNameW(NULL, &path[0], static_cast<DWORD>(path.size()));
+    path.resize(len);
+    size_t pos = path.find_last_of(L"\\/");
+    return (pos != std::wstring::npos) ? path.substr(0, pos) : L".";
+}
+
+static void inline print_usage()
+{
+    printf
+    (
+        "Usage:\n"
+        "  qdinstall.exe -i\n"
+        "  qdinstall.exe -x\n"
+        "  qdinstall.exe -v\n"
+    );
+}
+
+static DWORD parse_args(int argc, wchar_t *argv[], Options &opts)
+{
+    for (int i = 1; i < argc; i++)
+    {
+        std::wstring arg = argv[i];
+
+        if (arg == L"-i")
+        {
+            opts.install = true;
+            opts.uninstall = false;
+        }
+        else if (arg == L"-x")
+        {
+            opts.uninstall = true;
+            opts.install = false;
+        }
+        else if (arg == L"-v")
+        {
+            opts.version = true;
+        }
+        else if (arg == L"-g")
+        {
+            opts.getInstallPath = true;
+        }
+        else if (arg == L"-p")
+        {
+            if ((i + 1) >= argc)
+            {
+                printf("ERROR: invalid installation path\n");
+                return ERROR_INVALID_PARAMETER;
+            }
+            opts.installationPath = argv[++i];
+            while (!opts.installationPath.empty() &&
+                   (opts.installationPath.back() == L'\\' || opts.installationPath.back() == L'/'))
+                opts.installationPath.pop_back();
+            if (opts.installationPath.empty())
+            {
+                printf("ERROR: invalid installation path\n");
+                return ERROR_INVALID_PARAMETER;
+            }
+            DWORD attr = GetFileAttributesW(opts.installationPath.c_str());
+            if (attr == INVALID_FILE_ATTRIBUTES)
+            {
+                printf("ERROR: installation path does not exist\n");
+                return ERROR_PATH_NOT_FOUND;
+            }
+            if (!(attr & FILE_ATTRIBUTE_DIRECTORY))
+            {
+                printf("ERROR: installation path is not a directory\n");
+                return ERROR_DIRECTORY;
+            }
+        }
+        else
+        {
+            printf("ERROR: unknown option: %ws\n", argv[i]);
+            return ERROR_INVALID_PARAMETER;
+        }
+    }
+
+    return ERROR_SUCCESS;
+}
+
+int wmain(int argc, wchar_t *argv[])
+{
+    Options opts;
+    DWORD ret = parse_args(argc, argv, opts);
+    if (ret != ERROR_SUCCESS)
+    {
+        print_usage();
+        return ret;
+    }
+
+    if (opts.version)
+    {
+        printf("Package version:   %ws\n", QCOM_USB_DRIVERS_PRODUCT_VERSION_STRING_W);
+        printf("Installed version: %ws\n", get_registered_install_version().c_str());
+        return ERROR_SUCCESS;
+    }
+
+    if (opts.getInstallPath)
+    {
+        std::wstring location = get_registered_install_location();
+        if (location.empty())
+        {
+            printf("%ws\n", L"no driver installation found");
+            return ERROR_FILE_NOT_FOUND;
+        }
+        printf("%ws\n", location.c_str());
+        return ERROR_SUCCESS;
+    }
+
+    // Set working directory to exe's own directory
+    std::wstring exe_dir = get_exe_directory();
+    if (!SetCurrentDirectoryW(exe_dir.c_str()))
+    {
+        ret = GetLastError();
+        printf("ERROR: cannot set directory to '%ws' (0x%lX)\n", exe_dir.c_str(), ret);
+        return ret;
+    }
+
+    if (opts.install)
+    {
+        ret = install_drivers();
+        if (ret == ERROR_ACCESS_DENIED)
+        {
+            printf("ERROR: failed to install driver (admin required)\n");
+            return ret;
+        }
+        if (ret == ERROR_NO_MORE_ITEMS)
+        {
+            printf("INFO: driver already installed for qualcomm usb devices\n");
+            return ret;
+        }
+        if (ret == ERROR_SUCCESS_REBOOT_REQUIRED)
+        {
+            printf("INFO: reboot required to complete driver installation\n");
+            ret = ERROR_SUCCESS;
+        }
+        if (ret != ERROR_SUCCESS)
+        {
+            printf("ERROR: failed to install driver (0x%lX)\n", ret);
+            return ret;
+        }
+
+        if (!opts.installationPath.empty())
+        {
+            InstallationInfo info;
+            info.publisher       = QCOM_USB_DRIVERS_COMPANY_NAME_W;
+            info.displayName     = QCOM_USB_DRIVERS_PRODUCT_NAME_W;
+            info.displayVersion  = QCOM_USB_DRIVERS_PRODUCT_VERSION_STRING_W;
+            info.installLocation = opts.installationPath;
+            info.uninstallString = L"\"" + opts.installationPath + L"\\qdinstall.exe\" -x";
+            info.estimatedSizeKB = 0;
+
+            printf("\nRegistering installation ...\n");
+            printf("Location: %ws\n", opts.installationPath.c_str());
+            ret = register_installation(info);
+            if (ret != ERROR_SUCCESS)
+            {
+                printf("ERROR: failed to write uninstall info (0x%lX)\n", ret);
+                return ret;
+            }
+        }
+    }
+    else if (opts.uninstall)
+    {
+        printf("\nCleaning up registry entries ...\n");
+        ret = unregister_installation();
+        if (ret != ERROR_SUCCESS)
+        {
+            printf("WARNING: failed to clean up registry (0x%lX), continuing...\n", ret);
+        }
+        ret = uninstall_drivers();
+        if (ret != ERROR_SUCCESS)
+        {
+            printf("ERROR: failed to uninstall driver (0x%lX)\n", ret);
+            return ret;
+        }
+    }
+
+    return ERROR_SUCCESS;
+}

--- a/src/windows/tools/qdinstall/main.cpp
+++ b/src/windows/tools/qdinstall/main.cpp
@@ -68,7 +68,7 @@ DWORD install_drivers()
     // Find and install each .inf in current directory
     DWORD ret = ERROR_SUCCESS;
     WIN32_FIND_DATAW fd;
-    std::wstring search_pattern = std::wstring(PATH_INF_DIR) + L".\\*.inf";
+    std::wstring search_pattern = std::wstring(PATH_INF_DIR) + L"*.inf";
     HANDLE hFind = FindFirstFileW(search_pattern.c_str(), &fd);
 
     if (hFind == INVALID_HANDLE_VALUE)
@@ -286,17 +286,17 @@ int wmain(int argc, wchar_t *argv[])
     }
     else if (opts.uninstall)
     {
+        ret = uninstall_drivers();
+        if (ret != ERROR_SUCCESS && ret != ERROR_FILE_NOT_FOUND)
+        {
+            printf("ERROR: failed to uninstall driver (0x%lX)\n", ret);
+            return ret;
+        }
         printf("\nCleaning up registry entries ...\n");
         ret = unregister_installation();
         if (ret != ERROR_SUCCESS)
         {
             printf("WARNING: failed to clean up registry (0x%lX), continuing...\n", ret);
-        }
-        ret = uninstall_drivers();
-        if (ret != ERROR_SUCCESS)
-        {
-            printf("ERROR: failed to uninstall driver (0x%lX)\n", ret);
-            return ret;
         }
     }
 

--- a/src/windows/tools/qdinstall/main.h
+++ b/src/windows/tools/qdinstall/main.h
@@ -1,0 +1,29 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <windows.h>
+#include <cfgmgr32.h>
+#include <string>
+
+struct Options
+{
+    bool install = true;    // default action
+    bool uninstall = false;
+    bool version = false;
+    bool getInstallPath = false;
+    std::wstring installationPath;
+};
+
+// Trigger a hardware scan to re-enumerate the device tree.
+DWORD scan_for_hardware_changes();
+
+// Run an external process and wait for it to complete.
+DWORD execute_command(const std::wstring &command);
+
+// Install all .inf drivers from the current directory.
+DWORD install_drivers();
+
+// Uninstall drivers (run qdclr to clean DriverStore, then rescan).
+DWORD uninstall_drivers();

--- a/src/windows/tools/qdinstall/qdinstall.sln
+++ b/src/windows/tools/qdinstall/qdinstall.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.35706.149
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qdinstall", "qdinstall.vcxproj", "{310A23E0-E90D-455E-AEDA-1B7044B1C921}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Debug|ARM64.Build.0 = Debug|ARM64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Debug|x64.ActiveCfg = Debug|x64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Debug|x64.Build.0 = Debug|x64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Debug|x86.ActiveCfg = Debug|Win32
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Debug|x86.Build.0 = Debug|Win32
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Release|ARM64.ActiveCfg = Release|ARM64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Release|ARM64.Build.0 = Release|ARM64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Release|x64.ActiveCfg = Release|x64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Release|x64.Build.0 = Release|x64
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Release|x86.ActiveCfg = Release|Win32
+		{310A23E0-E90D-455E-AEDA-1B7044B1C921}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9C0B7883-B590-488C-833A-9BF0670ECC58}
+	EndGlobalSection
+EndGlobal

--- a/src/windows/tools/qdinstall/qdinstall.vcxproj
+++ b/src/windows/tools/qdinstall/qdinstall.vcxproj
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{310a23e0-e90d-455e-aeda-1b7044b1c921}</ProjectGuid>
+    <RootNamespace>qdinstall</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="main.h" />
+    <ClInclude Include="registry.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="registry.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/windows/tools/qdinstall/registry.cpp
+++ b/src/windows/tools/qdinstall/registry.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "registry.h"
+
+static bool set_registry_string(HKEY hKey, const wchar_t *name, const std::wstring &value, DWORD &error_code)
+{
+    error_code = RegSetValueExW(hKey, name, 0, REG_SZ,
+                              reinterpret_cast<const BYTE *>(value.c_str()),
+                              static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t)));
+
+    return (error_code == ERROR_SUCCESS);
+}
+
+static bool set_registry_dword(HKEY hKey, const wchar_t *name, DWORD value, DWORD &error_code)
+{
+    error_code = RegSetValueExW(hKey, name, 0, REG_DWORD,
+                              reinterpret_cast<const BYTE *>(&value), sizeof(DWORD));
+
+    return (error_code == ERROR_SUCCESS);
+}
+
+static std::wstring get_registry_string(HKEY hKey, const wchar_t *name, DWORD &error_code)
+{
+    DWORD type = 0;
+    DWORD size = 0;
+
+    error_code = RegQueryValueExW(hKey, name, nullptr, &type, nullptr, &size);
+    if (error_code != ERROR_SUCCESS || type != REG_SZ || size == 0)
+    {
+        return {};
+    }
+
+    std::wstring value(size / sizeof(wchar_t), L'\0');
+    error_code = RegQueryValueExW(hKey, name, nullptr, &type,
+                           reinterpret_cast<BYTE *>(&value[0]), &size);
+    if (error_code != ERROR_SUCCESS)
+    {
+        return {};
+    }
+
+    // Remove trailing null if present
+    if (!value.empty() && value.back() == L'\0')
+    {
+        value.pop_back();
+    }
+
+    return value;
+}
+
+DWORD register_installation(const InstallationInfo &info)
+{
+    HKEY hKey = nullptr;
+    DWORD disposition = 0;
+    DWORD ret = RegCreateKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, 0, nullptr,
+                               REG_OPTION_NON_VOLATILE, KEY_WRITE | KEY_WOW64_64KEY, nullptr, &hKey, &disposition);
+    if (ret == ERROR_SUCCESS)
+    {
+        bool success = true;
+        success = success && set_registry_string(hKey, L"Publisher", info.publisher, ret);
+        success = success && set_registry_string(hKey, L"DisplayName", info.displayName, ret);
+        success = success && set_registry_string(hKey, L"DisplayVersion", info.displayVersion, ret);
+        success = success && set_registry_string(hKey, L"InstallLocation", info.installLocation, ret);
+        success = success && set_registry_string(hKey, L"UninstallString", info.uninstallString, ret);
+        success = success && set_registry_dword(hKey, L"NoModify", 1, ret);
+        success = success && set_registry_dword(hKey, L"NoRepair", 1, ret);
+        success = success && set_registry_dword(hKey, L"EstimatedSize", info.estimatedSizeKB, ret);
+
+        RegCloseKey(hKey);
+    }
+
+    return ret;
+}
+
+DWORD unregister_installation()
+{
+    HKEY hKey = nullptr;
+    DWORD ret = RegOpenKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, 0,
+                              KEY_READ | KEY_WRITE | KEY_WOW64_64KEY, &hKey);
+
+    if (ret == ERROR_SUCCESS)
+    {
+        RegDeleteTreeW(hKey, nullptr);
+        RegCloseKey(hKey);
+        return RegDeleteKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, KEY_WOW64_64KEY, 0);
+    }
+    
+    return (ret == ERROR_FILE_NOT_FOUND) ? ERROR_SUCCESS : ret;
+}
+
+bool is_installation_registered()
+{
+    HKEY hKey = nullptr;
+    DWORD ret = RegOpenKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+
+    if (ret == ERROR_SUCCESS)
+    {
+        RegCloseKey(hKey);
+        return true;
+    }
+
+    return false;
+}
+
+std::wstring get_registered_install_location()
+{
+    HKEY hKey = nullptr;
+    DWORD ret = RegOpenKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+
+    if (ret != ERROR_SUCCESS)
+    {
+        return {};
+    }
+
+    std::wstring value = get_registry_string(hKey, L"InstallLocation", ret);
+    RegCloseKey(hKey);
+
+    return value;
+}
+
+std::wstring get_registered_install_version()
+{
+    HKEY hKey = nullptr;
+    DWORD ret = RegOpenKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+
+    if (ret != ERROR_SUCCESS)
+    {
+        return {};
+    }
+
+    std::wstring value = get_registry_string(hKey, L"DisplayVersion", ret);
+    RegCloseKey(hKey);
+
+    return value;
+}

--- a/src/windows/tools/qdinstall/registry.h
+++ b/src/windows/tools/qdinstall/registry.h
@@ -1,0 +1,27 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <windows.h>
+#include <string>
+
+constexpr const wchar_t *uninstall_registry_key =
+    L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Qualcomm USB Drivers";
+
+struct InstallationInfo
+{
+    std::wstring publisher;
+    std::wstring displayName;
+    std::wstring displayVersion;
+    std::wstring installLocation;
+    std::wstring uninstallString;
+    DWORD estimatedSizeKB = 0;
+};
+
+// Registration functions — return ERROR_SUCCESS (0) on success, Win32 error code on failure.
+DWORD register_installation(const InstallationInfo &info);
+DWORD unregister_installation();
+bool is_installation_registered();
+std::wstring get_registered_install_location();
+std::wstring get_registered_install_version();

--- a/src/windows/tools/wwansvc/qcmtusvc.sln
+++ b/src/windows/tools/wwansvc/qcmtusvc.sln
@@ -4,14 +4,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qcmtusvc", "qcmtusvc.vcxpro
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
-		Release|Win32 = Release|Win32
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Debug|Win32.ActiveCfg = Debug|Win32
-		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Debug|Win32.Build.0 = Debug|Win32
-		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Release|Win32.ActiveCfg = Release|Win32
-		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Release|Win32.Build.0 = Release|Win32
+		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Debug|x86.ActiveCfg = Debug|Win32
+		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Debug|x86.Build.0 = Debug|Win32
+		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Release|x86.ActiveCfg = Release|Win32
+		{7D888E32-457F-4E3F-A294-E9B7015AD7D0}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION

## Add Windows driver installer tool and build pipeline

### Summary

This PR introduces a complete Windows driver installation solution: a native `qdinstall` tool for low-level driver management, a self-extracting C# installer executable for end-user distribution, and the build scripts that tie everything together for x86, x64, and arm64 platforms.

### Changes

#### 1. New: `qdinstall` tool (`src/windows/tools/qdinstall/`)

A native C++ command-line utility for driver lifecycle management:

| Flag | Action |
|------|--------|
| `-i` | Install — removes stale drivers via `qdclr.exe`, installs all `.inf` drivers using `pnputil`, triggers device re-enumeration, and registers the installation in the Windows registry (Add/Remove Programs). |
| `-x` | Uninstall — cleans the DriverStore via `qdclr.exe`, removes registry entries, and re-enumerates the device tree. |
| `-v` | Show package version and currently-installed version from registry. |
| `-g` | Print the registered installation path. |
| `-p <path>` | Specify the installation directory (used by the outer installer). |

- Supports x86, x64, and arm64 platforms.
- Registers under `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Qualcomm USB Drivers`.

**Files:** `main.cpp`, `main.h`, `registry.cpp`, `registry.h`, `qdinstall.sln`, `qdinstall.vcxproj`

#### 2. New: Self-extracting installer (`build/build-installer.ps1`)

A PowerShell script that:

1. **Packages the payload** — stages `target/Drivers/` and `target/Tools/` into a zip, promoting `qdclr.exe` and `qdinstall.exe` to the payload root for direct execution.
2. **Compiles a C# self-extracting EXE** — embeds the payload zip as a .NET manifest resource and compiles via `csc.exe` (Framework 4.0). The resulting executable:
   - Supports `--install` (default), `--uninstall`, and `--version` flags.
   - Auto-elevates to administrator via UAC (`runas` verb).
   - On install: extracts payload to a temp directory, uninstalls legacy packages (`qualcomm_userspace_driver`, `qud`, `qud.slt`, `qud.internal`) via `qpm-cli`, runs `qdinstall.exe -i -p <installPath>`, then copies all files to `%ProgramFiles%\Qualcomm\Qualcomm USB Drivers`.
   - On uninstall: reads the uninstall command from the registry, executes it, and deletes the installation directory.
3. **Reads version** from `src/windows/qcversion.h` and stamps it into the assembly metadata.

#### 3. New: Build scripts (`build/`)

| Script | Purpose |
|--------|---------|
| `build_tools.ps1` | Builds all tool projects (qcdev, qdcfg, qdclr, qdinstall, wwansvc) via MSBuild with auto-detection of Visual Studio. Supports platform-specific fallback (e.g., x86-only tools build as x86 regardless of target). |
| `build-installer.ps1` | Assembles payload and compiles the C# self-extracting installer (see above). |
| `build_installer.bat` | Top-level orchestrator — loops over x86/x64/arm64, invokes `build_tools.ps1`, `build-installer.ps1`, and `sign.ps1` for each architecture. Produces `qcom_usb_kernel_drivers_{x86,x64,arm64}.exe`. |

#### 4. Renames

- `build_all.bat` → `build_drivers.bat` (clarifies scope — driver `.sys`/`.inf` build only)
- `build.ps1` → `build_drivers.ps1` (same)

### Install Flow

```
qcom_usb_kernel_drivers_x64.exe (C# self-extractor)
  → UAC elevation
  → Extract payload.zip to %TEMP%
  → Uninstall legacy packages via qpm-cli
  → Run qdinstall.exe -i -p "%ProgramFiles%\Qualcomm\Qualcomm USB Drivers"
      → qdclr.exe (remove old DriverStore entries)
      → pnputil /add-driver *.inf /install /force
      → Device tree re-enumeration
      → Registry registration (Add/Remove Programs)
  → Copy payload to install path
```

### Uninstall Flow

```
qcom_usb_kernel_drivers_x64.exe /uninstall, or uninstall from control panel
  → UAC elevation
  → Fetch uninstall string from registry
  → Run qdinstall.exe -x
      → qdclr.exe (remove DriverStore entries)
      → Remove registry registration
  → Delete the installation directory
```

### Testing

- Built installers for all three architectures.
- Verified install and uninstall flows on Windows.

---

Let me know if you'd like any adjustments, or toggle to Act mode if you want me to save this to a file.