### PR TITLE
Fix device suspend issue introduced in interval timeout implementation

### DIFF
--- a/src/windows/wdfserial/QCRD.c
+++ b/src/windows/wdfserial/QCRD.c
@@ -562,7 +562,8 @@ void QCRD_ReadRequestHandlerThread
                 // and a request is pending in the timeout queue. This resets the
                 // inter-byte gap timer so the request completes only after the
                 // device stops sending data for ReadIntervalTimeout milliseconds.
-                if (pDevContext->ReadTimeout.bUseReadInterval &&
+                if (bDeviceAwaken &&
+                    pDevContext->ReadTimeout.bUseReadInterval &&
                     !QCUTIL_IsIoQueueEmpty(pDevContext->TimeoutReadQueue) &&
                     pDevContext->Timeouts.ReadIntervalTimeout > 0)
                 {


### PR DESCRIPTION
### Summary
During D0 exit, cancelled URBs fire COMPLETION_EVENT with 0 bytes. 
Without this status check, the timer would be re-armed while the device
is in Dx, causing the TimeoutReadQueue request to complete and apps 
to post a new ReadFile into the power-managed ReadQueue, which
immediately wakes the device. This creates an infinite wake/sleep cycle 
that prevents selective suspend.

### Related Pull Request
- https://github.com/qualcomm/qcom-usb-kernel-drivers/pull/24

### Validation
- Confirmed working by end user.
