### PR TITLE
Update qdclr project to detect and remove winusb drivers during uninstallation

### DIFF
--- a/src/windows/tools/qdclr/infdev.cpp
+++ b/src/windows/tools/qdclr/infdev.cpp
@@ -307,6 +307,10 @@ BOOL DeviceMatch(PTSTR InfText, DWORD TextSize)
     {
         matchFound = TRUE;
     }
+	else if (StrStrW(InfText, TEXT("libusb-win32 devices")) != NULL)    // userspace (WinUSB)
+    {
+        matchFound = TRUE;
+    }
 
     return matchFound;
 }


### PR DESCRIPTION
### Summary

> Updated qdclr project to remove userspace drivers during uninstallation

