### PR TITLE
fix(deb): move qpm-cli uninstall to preinst to fix double-install [QUD-1886]

### DIFF
--- a/src/linux/build-deb.sh
+++ b/src/linux/build-deb.sh
@@ -175,7 +175,11 @@ Description: $DESCRIPTION
 EOF
 chmod 0644 "$BUILDROOT/DEBIAN/control"
 
-# Create DEBIAN/preinst - reset log file
+# Create DEBIAN/preinst - uninstall any qpm-cli QUD, then reset the build dir
+# NOTE [QUD-1886]: qpm-cli uninstall MUST run here (preinst), before dpkg extracts
+# the package payload.  If it runs in postinst the qpm-cli uninstall removes the
+# freshly-extracted files (including qcom_drivers.sh), causing the first
+# "sudo dpkg -i" to fail with "qcom_drivers.sh not found or not executable".
 cat > "$BUILDROOT/DEBIAN/preinst" <<EOF
 #!/usr/bin/env bash
 set -e
@@ -186,17 +190,54 @@ LOG_FILE="\$INSTALL_ROOT/qcom_kernel_install.log"
 
 mkdir -p "\$INSTALL_ROOT" || true
 
-# Remove any previous extracted build folder so we start fresh
-if [ -d "\$INSTALL_PREFIX" ]; then
-  rm -rf "\$INSTALL_PREFIX" || true
-fi
-mkdir -p "\$INSTALL_PREFIX" || true
-
 if [ -e "\$LOG_FILE" ]; then
   rm -f "\$LOG_FILE" || true
 fi
 touch "\$LOG_FILE" || true
 chmod 0644 "\$LOG_FILE" || true
+
+# Uninstall any QUD driver previously installed via qpm-cli BEFORE dpkg extracts
+# the new payload.  Running this in postinst (as was done before QUD-1886 fix)
+# caused qpm-cli to delete the freshly-extracted qcom_drivers.sh, making the
+# first dpkg install silently incomplete.
+{
+  echo ""
+  echo "=================================================================="
+  echo "[QUD] qpm-cli QUD uninstall (qud.internal / qud / qud.slt)"
+  echo "=================================================================="
+} >> "\$LOG_FILE" 2>&1
+if command -v qpm-cli >/dev/null 2>&1; then
+  QUD_INTERNAL_VERSION="\$(qpm-cli --info qud.internal 2>/dev/null | grep "Installed" | awk '{printf \$4}')"
+  QUD_EXTERNAL_VERSION="\$(qpm-cli --info qud 2>/dev/null | grep "Installed" | awk '{printf \$4}')"
+  QUD_SLT_VERSION="\$(qpm-cli --info qud.slt 2>/dev/null | grep "Installed" | awk '{printf \$4}')"
+
+  if [ -n "\$QUD_INTERNAL_VERSION" ] || [ -n "\$QUD_EXTERNAL_VERSION" ] || [ -n "\$QUD_SLT_VERSION" ]; then
+    if [ -n "\$QUD_INTERNAL_VERSION" ]; then
+      echo "[QUD] Uninstalling qud.internal (\$QUD_INTERNAL_VERSION) via qpm-cli..." >> "\$LOG_FILE" 2>&1
+      qpm-cli --uninstall qud.internal --silent --force >> "\$LOG_FILE" 2>&1 || true
+    fi
+    if [ -n "\$QUD_EXTERNAL_VERSION" ]; then
+      echo "[QUD] Uninstalling qud (\$QUD_EXTERNAL_VERSION) via qpm-cli..." >> "\$LOG_FILE" 2>&1
+      qpm-cli --uninstall qud --silent --force >> "\$LOG_FILE" 2>&1 || true
+    fi
+    if [ -n "\$QUD_SLT_VERSION" ]; then
+      echo "[QUD] Uninstalling qud.slt (\$QUD_SLT_VERSION) via qpm-cli..." >> "\$LOG_FILE" 2>&1
+      qpm-cli --uninstall qud.slt --silent --force >> "\$LOG_FILE" 2>&1 || true
+    fi
+  else
+    echo "[QUD] No qpm-cli QUD installation found, nothing to uninstall." >> "\$LOG_FILE" 2>&1
+  fi
+else
+  echo "[QUD] qpm-cli not available, skipping qpm-cli QUD uninstall." >> "\$LOG_FILE" 2>&1
+fi
+
+# Remove any previous extracted build folder so we start fresh.
+# This runs AFTER qpm-cli uninstall so qpm-cli has already cleaned up its own
+# files; dpkg will then extract the new payload into a clean directory.
+if [ -d "\$INSTALL_PREFIX" ]; then
+  rm -rf "\$INSTALL_PREFIX" || true
+fi
+mkdir -p "\$INSTALL_PREFIX" || true
 
 exit 0
 EOF
@@ -270,32 +311,10 @@ if [ -n "\$USERSPACE_DPKG_TAIL" ]; then
   printf '%s\n' "\$USERSPACE_DPKG_TAIL" | sed 's/^/[dpkg logs] /' >> "\$LOG_FILE" 2>&1
 fi
 
-# Uninstall any QUD driver previously installed via qpm-cli
-LOG_HEADER "qpm-cli QUD uninstall (qud.internal / qud / qud.slt)"
-if command -v qpm-cli >/dev/null 2>&1; then
-  QUD_INTERNAL_VERSION="\$(qpm-cli --info qud.internal 2>/dev/null | grep "Installed" | awk '{printf \$4}')"
-  QUD_EXTERNAL_VERSION="\$(qpm-cli --info qud 2>/dev/null | grep "Installed" | awk '{printf \$4}')"
-  QUD_SLT_VERSION="\$(qpm-cli --info qud.slt 2>/dev/null | grep "Installed" | awk '{printf \$4}')"
-
-  if [ -n "\$QUD_INTERNAL_VERSION" ] || [ -n "\$QUD_EXTERNAL_VERSION" ] || [ -n "\$QUD_SLT_VERSION" ]; then
-    if [ -n "\$QUD_INTERNAL_VERSION" ]; then
-      echo "[QUD] Uninstalling qud.internal (\$QUD_INTERNAL_VERSION) via qpm-cli..." >> "\$LOG_FILE" 2>&1
-      qpm-cli --uninstall qud.internal --silent --force >> "\$LOG_FILE" 2>&1 || true
-    fi
-    if [ -n "\$QUD_EXTERNAL_VERSION" ]; then
-      echo "[QUD] Uninstalling qud (\$QUD_EXTERNAL_VERSION) via qpm-cli..." >> "\$LOG_FILE" 2>&1
-      qpm-cli --uninstall qud --silent --force >> "\$LOG_FILE" 2>&1 || true
-    fi
-    if [ -n "\$QUD_SLT_VERSION" ]; then
-      echo "[QUD] Uninstalling qud.slt (\$QUD_SLT_VERSION) via qpm-cli..." >> "\$LOG_FILE" 2>&1
-      qpm-cli --uninstall qud.slt --silent --force >> "\$LOG_FILE" 2>&1 || true
-    fi
-  else
-    echo "The User hasn't installed QUD driver via qpm-cli" >> "\$LOG_FILE" 2>&1
-  fi
-else
-  echo "[QUD] qpm-cli not available, skipping qpm-cli QUD uninstall." >> "\$LOG_FILE" 2>&1
-fi
+# qpm-cli uninstall was moved to preinst (QUD-1886 fix) so it runs before dpkg
+# extracts the package payload.  postinst no longer needs to do it.
+LOG_HEADER "qpm-cli QUD uninstall"
+echo "[QUD] qpm-cli uninstall was already performed in preinst (before payload extraction)." >> "\$LOG_FILE" 2>&1
 
 LOG_HEADER "Legacy QUD cleanup"
 if [ -x "\$INSTALL_PREFIX/legacy/installer/QcDevDriver.sh" ]; then


### PR DESCRIPTION
## Summary

Fix the Debian package requiring two consecutive `sudo dpkg -i` invocations to install successfully.

**Symptom:** First `dpkg -i` leaves the package in a broken `half-configured` state with no kernel modules loaded; second `dpkg -i` succeeds.

---

## Root Cause

### dpkg lifecycle recap

```
preinst  →  [dpkg extracts payload]  →  postinst
```

`preinst` runs **before** files are written to disk.  
`postinst` runs **after** files are written to disk.

### What was happening (broken)

The `postinst` script contained a block that called:

```bash
qpm-cli --uninstall qud --silent --force
```

On a system where QUD had previously been installed via `qpm-cli`, this uninstall ran **after** dpkg had already extracted the package payload to `/opt/qcom/QUD/build/`. The qpm-cli uninstall removed those freshly-extracted files — including `qcom_drivers.sh` — before `postinst` had a chance to run it.

### Exact failure sequence

```
[QUD] Uninstalling qud (1.0.6.4) via qpm-cli...
[Info] : Removing files
[Info] : Force uninstall completed
...
[QUD] Executing qcom_drivers.sh install from /opt/qcom/QUD/build...
[QUD] ERROR: /opt/qcom/QUD/build/qcom_drivers.sh not found or not executable.
```

Because `postinst` exits 0 regardless, dpkg marked the package as `installed` even though no kernel modules were compiled or loaded:

```
status half-configured qud:all 1.0.6.4   ← postinst failed silently
status installed       qud:all 1.0.6.4   ← dpkg accepted exit 0
```

### Why the second install worked

On the second `dpkg -i`, qpm-cli no longer had a record of `qud` (it was already uninstalled in the first run), so it did **not** delete the freshly-extracted files. `postinst` found `qcom_drivers.sh` intact and the installation completed successfully.

---

## Fix

Move the `qpm-cli` uninstall block from `DEBIAN/postinst` to `DEBIAN/preinst`.

`preinst` runs **before** dpkg extracts the payload, so the corrected sequence is:

| Step | Script | Action |
|------|--------|--------|
| 1 | `preinst` | `qpm-cli --uninstall qud` — removes old qpm-cli installation while no dpkg files exist yet |
| 2 | dpkg | Extracts new payload to `/opt/qcom/QUD/build/` (clean directory) |
| 3 | `postinst` | Finds `qcom_drivers.sh` intact → compiles and loads `qcom_usb.ko` ✓ |

### Before (broken)

```
preinst:   [reset log, clean build dir]
dpkg:      extract → /opt/qcom/QUD/build/qcom_drivers.sh  ← FILE EXISTS
postinst:  qpm-cli --uninstall qud                         ← DELETES THE FILE
postinst:  ./qcom_drivers.sh install                       ← FILE NOT FOUND ✗
```

### After (fixed)

```
preinst:   qpm-cli --uninstall qud                         ← removes old install
preinst:   [reset log, clean build dir]
dpkg:      extract → /opt/qcom/QUD/build/qcom_drivers.sh  ← FILE EXISTS
postinst:  ./qcom_drivers.sh install                       ← SUCCESS ✓
```

---

## Files Changed

| File | Change |
|------|--------|
| `src/linux/build-deb.sh` | Move qpm-cli uninstall block from `DEBIAN/postinst` heredoc to `DEBIAN/preinst` heredoc |

**Diff summary:** 1 file changed, 52 insertions(+), 33 deletions(-)

---

## Testing

**To reproduce the bug (before fix):**
1. Install QUD on a clean Ubuntu 22.04 system via `qpm-cli install qud`
2. Build the `.deb` from the unfixed branch: `./src/linux/build-deb.sh`
3. Run `sudo dpkg -i build/qud_<version>_all.deb` — first attempt fails silently (no modules loaded)
4. Run `sudo dpkg -i build/qud_<version>_all.deb` again — second attempt succeeds

**To verify the fix:**
1. Install QUD on a clean Ubuntu 22.04 system via `qpm-cli install qud`
2. Build the `.deb` from this branch: `./src/linux/build-deb.sh`
3. Run `sudo dpkg -i build/qud_<version>_all.deb` — should succeed on the **first** attempt
4. Verify `lsmod | grep qcom_usb` shows the module loaded
5. Verify `pcat -devices` detects connected Qualcomm devices