### PR TITLE
Add release workflow for Linux and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,389 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      linux_version:
+        description: >
+          Linux driver version to release (e.g. 1.0.6.5).
+          Leave empty to skip the Linux release.
+        required: false
+        type: string
+        default: ''
+      windows_version:
+        description: >
+          Windows driver version to release (e.g. 1.00.94.6).
+          Leave empty to skip the Windows release.
+        required: false
+        type: string
+        default: ''
+      base_branch:
+        description: 'Base branch to cut the release from'
+        required: false
+        type: string
+        default: 'main'
+      release_notes:
+        description: 'Release notes (Markdown). Defaults to auto-generated notes.'
+        required: false
+        type: string
+        default: ''
+      draft:
+        description: 'Create as draft release (publish manually afterwards)'
+        required: false
+        type: boolean
+        default: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+env:
+  GIT_AUTHOR_NAME: github-actions[bot]
+  GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+  GIT_COMMITTER_NAME: github-actions[bot]
+  GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────────────
+  # Validate inputs before doing any real work
+  # ───────────────────────────────────────────────────────────────────────────
+  validate:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    outputs:
+      do_linux: ${{ steps.check.outputs.do_linux }}
+      do_windows: ${{ steps.check.outputs.do_windows }}
+    steps:
+      - name: Check that at least one version was supplied
+        id: check
+        run: |
+          LNX="${{ inputs.linux_version }}"
+          WIN="${{ inputs.windows_version }}"
+
+          if [ -z "$LNX" ] && [ -z "$WIN" ]; then
+            echo "ERROR: At least one of linux_version or windows_version must be provided."
+            exit 1
+          fi
+
+          # Validate Linux version format  X.X.X.X
+          if [ -n "$LNX" ]; then
+            if ! echo "$LNX" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "ERROR: linux_version '$LNX' does not match expected format X.X.X.X"
+              exit 1
+            fi
+            echo "do_linux=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "do_linux=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Validate Windows version format  X.XX.XX.X
+          if [ -n "$WIN" ]; then
+            if ! echo "$WIN" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "ERROR: windows_version '$WIN' does not match expected format X.XX.XX.X"
+              exit 1
+            fi
+            echo "do_windows=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "do_windows=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Linux release
+  # ───────────────────────────────────────────────────────────────────────────
+  release-linux:
+    name: Linux release ${{ inputs.linux_version }}
+    needs: validate
+    if: needs.validate.outputs.do_linux == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
+
+      # ── 1. Create release branch ──────────────────────────────────────────
+      - name: Create release branch
+        id: branch
+        run: |
+          VERSION="${{ inputs.linux_version }}"
+          BRANCH="release-lnx-${VERSION}"
+
+          if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            echo "ERROR: Branch '${BRANCH}' already exists on remote."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # ── 2. Bump version in version.h ──────────────────────────────────────
+      - name: Update src/linux/version.h
+        run: |
+          VERSION="${{ inputs.linux_version }}"
+          FILE="src/linux/version.h"
+
+          sed -i "s/#define DRIVER_VERSION \".*\"/#define DRIVER_VERSION \"${VERSION}\"/" "$FILE"
+
+          echo "Updated $FILE:"
+          cat "$FILE"
+
+          # Verify the change landed
+          grep -q "\"${VERSION}\"" "$FILE" || \
+            { echo "ERROR: version.h was not updated correctly"; exit 1; }
+
+      # ── 3. Commit & push release branch ───────────────────────────────────
+      - name: Commit version bump
+        run: |
+          VERSION="${{ inputs.linux_version }}"
+          git add src/linux/version.h
+          git commit -m "Update Linux driver version to ${VERSION}"
+
+      - name: Push release branch
+        run: |
+          git push origin "${{ steps.branch.outputs.branch }}"
+
+      # ── 4. Build .deb package ─────────────────────────────────────────────
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends dpkg-dev
+
+      - name: Build deb package
+        run: |
+          cd src/linux
+          bash build-deb.sh
+          echo "Build output:"
+          ls -lh build/
+
+      # ── 5. Package release artifact ───────────────────────────────────────
+      - name: Create release zip
+        id: zip
+        run: |
+          VERSION="${{ inputs.linux_version }}"
+          DIR_NAME="qud_${VERSION}_all"
+          ZIP_NAME="${DIR_NAME}.zip"
+          DEB_FILE="src/linux/build/qud_${VERSION}_all.deb"
+
+          if [ ! -f "$DEB_FILE" ]; then
+            echo "ERROR: Expected deb not found: $DEB_FILE"
+            ls src/linux/build/ || true
+            exit 1
+          fi
+
+          mkdir -p "release_staging/${DIR_NAME}"
+          cp "$DEB_FILE"              "release_staging/${DIR_NAME}/"
+          cp "src/linux/RELEASES.md"  "release_staging/${DIR_NAME}/"
+
+          # Prefer src/linux/README.md, fall back to repo root README.md
+          if [ -f "src/linux/README.md" ]; then
+            cp "src/linux/README.md" "release_staging/${DIR_NAME}/"
+          elif [ -f "README.md" ]; then
+            cp "README.md" "release_staging/${DIR_NAME}/"
+          fi
+
+          (cd release_staging && zip -r "../${ZIP_NAME}" "${DIR_NAME}/")
+
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+          echo "zip_path=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Release zip contents:"
+          unzip -l "$ZIP_NAME"
+
+      # ── 6. Create tag ─────────────────────────────────────────────────────
+      - name: Create and push tag
+        id: tag
+        run: |
+          VERSION="${{ inputs.linux_version }}"
+          TAG="release-lnx-v${VERSION}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "ERROR: Tag '${TAG}' already exists on remote."
+            exit 1
+          fi
+
+          git tag -a "$TAG" -m "Linux release v${VERSION}"
+          git push origin "$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # ── 7. Create GitHub release ──────────────────────────────────────────
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ inputs.linux_version }}"
+          TAG="${{ steps.tag.outputs.tag }}"
+          NOTES="${{ inputs.release_notes }}"
+
+          if [ -z "$NOTES" ]; then
+            NOTES="## Linux driver release v${VERSION}
+
+          Built from branch \`${{ steps.branch.outputs.branch }}\`.
+
+          ### Installation
+          \`\`\`bash
+          sudo dpkg -i qud_${VERSION}_all.deb
+          \`\`\`
+
+          ### Uninstall
+          \`\`\`bash
+          sudo dpkg -r qud
+          \`\`\`"
+          fi
+
+          DRAFT_FLAG=""
+          if [ "${{ inputs.draft }}" = "true" ]; then
+            DRAFT_FLAG="--draft"
+          fi
+
+          gh release create "$TAG" \
+            "${{ steps.zip.outputs.zip_path }}" \
+            --title "$TAG" \
+            --notes "$NOTES" \
+            $DRAFT_FLAG
+
+          echo "✅ Linux release created: $TAG"
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Windows release
+  #
+  # NOTE: Building signed Windows kernel drivers requires Visual Studio +
+  # Windows Driver Kit (WDK) and a code-signing certificate — tooling that is
+  # not available on standard GitHub-hosted runners.
+  #
+  # This job therefore:
+  #   1. Creates the release branch and bumps the version.
+  #   2. Creates the annotated tag.
+  #   3. Opens a DRAFT GitHub release so that the signed build artifacts
+  #      (produced by your internal Windows build pipeline) can be attached
+  #      before the release is published.
+  #
+  # To build locally:  .\build\build_drivers.ps1  (requires VS + WDK)
+  # ───────────────────────────────────────────────────────────────────────────
+  release-windows:
+    name: Windows release ${{ inputs.windows_version }}
+    needs: validate
+    if: needs.validate.outputs.do_windows == 'true'
+    runs-on: ubuntu-latest   # branch/tag/release work; no WDK needed here
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
+
+      # ── 1. Create release branch ──────────────────────────────────────────
+      - name: Create release branch
+        id: branch
+        run: |
+          VERSION="${{ inputs.windows_version }}"
+          BRANCH="release-win-${VERSION}"
+
+          if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            echo "ERROR: Branch '${BRANCH}' already exists on remote."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # ── 2. Bump version in qcversion.h ────────────────────────────────────
+      - name: Update src/windows/qcversion.h
+        run: |
+          VERSION="${{ inputs.windows_version }}"
+          # Convert dot-separated version to comma-separated for FILE_VERSION macros
+          VERSION_COMMA="${VERSION//./, }"
+          # Also produce the compact comma form used in the header (no spaces)
+          VERSION_COMMA_COMPACT="${VERSION//./ }"
+          VERSION_COMMA_COMPACT="${VERSION_COMMA_COMPACT// /,}"
+
+          FILE="src/windows/qcversion.h"
+
+          # Update QCOM_USB_DRIVERS_PRODUCT_VERSION  (bare version, no quotes)
+          sed -i "s/\(#define QCOM_USB_DRIVERS_PRODUCT_VERSION\s\+\)[^ ]*/\1${VERSION}/" "$FILE"
+
+          # Update QCOM_USB_DRIVERS_FILE_VERSION  (comma-separated)
+          sed -i "s/\(#define QCOM_USB_DRIVERS_FILE_VERSION\s\+\)[^[:space:]]*/\1${VERSION_COMMA_COMPACT}/" "$FILE"
+
+          echo "Updated $FILE (relevant lines):"
+          grep -E "QCOM_USB_DRIVERS_(PRODUCT|FILE)_VERSION\b" "$FILE"
+
+          # Verify
+          grep -q "QCOM_USB_DRIVERS_PRODUCT_VERSION ${VERSION}" "$FILE" || \
+            { echo "ERROR: PRODUCT_VERSION was not updated correctly"; exit 1; }
+
+      # ── 3. Commit & push release branch ───────────────────────────────────
+      - name: Commit version bump
+        run: |
+          VERSION="${{ inputs.windows_version }}"
+          git add src/windows/qcversion.h
+          git commit -m "Update Windows driver version to ${VERSION}"
+
+      - name: Push release branch
+        run: |
+          git push origin "${{ steps.branch.outputs.branch }}"
+
+      # ── 4. Create tag ─────────────────────────────────────────────────────
+      - name: Create and push tag
+        id: tag
+        run: |
+          VERSION="${{ inputs.windows_version }}"
+          TAG="release-win-v${VERSION}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "ERROR: Tag '${TAG}' already exists on remote."
+            exit 1
+          fi
+
+          git tag -a "$TAG" -m "Windows release v${VERSION}"
+          git push origin "$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # ── 5. Create draft GitHub release ────────────────────────────────────
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ inputs.windows_version }}"
+          TAG="${{ steps.tag.outputs.tag }}"
+          NOTES="${{ inputs.release_notes }}"
+
+          if [ -z "$NOTES" ]; then
+            NOTES="## Windows driver release v${VERSION}
+
+          Built from branch \`${{ steps.branch.outputs.branch }}\`.
+
+          > **Note:** Attach the signed build artifacts produced by the internal
+          > Windows build pipeline before publishing this release.
+          >
+          > Build locally with: \`.\build\build_drivers.ps1\` (requires Visual Studio + WDK)"
+          fi
+
+          # Windows releases always start as draft because signed artifacts
+          # must be attached by the internal build pipeline before publishing.
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "$NOTES" \
+            --draft
+
+          echo "✅ Windows draft release created: $TAG"
+          echo "   Attach signed build artifacts and publish when ready."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,41 @@ on:
         required: false
         type: string
         default: ''
+      filter_version:
+        description: >
+          Filter driver sub-version (e.g. 1.0.1.6).
+          Leave empty to keep the current value in qcversion.h.
+        required: false
+        type: string
+        default: ''
+      net_version:
+        description: >
+          NDIS/net driver sub-version (e.g. 5.0.1.2).
+          Leave empty to keep the current value in qcversion.h.
+        required: false
+        type: string
+        default: ''
+      wdfserial_version:
+        description: >
+          WDF serial driver sub-version (e.g. 1.0.3.7).
+          Leave empty to keep the current value in qcversion.h.
+        required: false
+        type: string
+        default: ''
+      qdss_version:
+        description: >
+          QDSS driver sub-version (e.g. 1.0.4.2).
+          Leave empty to keep the current value in qcversion.h.
+        required: false
+        type: string
+        default: ''
+      adb_version:
+        description: >
+          ADB driver sub-version (e.g. 1.0.1.7).
+          Leave empty to keep the current value in qcversion.h.
+        required: false
+        type: string
+        default: ''
       base_branch:
         description: 'Base branch to cut the release from'
         required: false
@@ -374,25 +409,47 @@ jobs:
       - name: Update src/windows/qcversion.h
         env:
           VERSION: ${{ inputs.windows_version }}
+          FILTER_VER: ${{ inputs.filter_version }}
+          NET_VER: ${{ inputs.net_version }}
+          WDFSERIAL_VER: ${{ inputs.wdfserial_version }}
+          QDSS_VER: ${{ inputs.qdss_version }}
+          ADB_VER: ${{ inputs.adb_version }}
         run: |
-          # Convert dot-separated version to comma-separated for FILE_VERSION macros
-          VERSION_COMMA="${VERSION//./, }"
-          # Also produce the compact comma form used in the header (no spaces)
-          VERSION_COMMA_COMPACT="${VERSION//./ }"
-          VERSION_COMMA_COMPACT="${VERSION_COMMA_COMPACT// /,}"
-
           FILE="src/windows/qcversion.h"
 
-          # Update QCOM_USB_DRIVERS_PRODUCT_VERSION  (bare version, no quotes)
-          sed -i "s/\(#define QCOM_USB_DRIVERS_PRODUCT_VERSION\s\+\)[^ ]*/\1${VERSION}/" "$FILE"
+          # Helper: update a VERSION + optional FILE_VERSION pair
+          update_driver_ver() {
+            local ver_macro="$1"
+            local file_macro="$2"   # pass "" to skip FILE_VERSION
+            local ver="$3"
+            [ -z "$ver" ] && return 0   # skip if not provided
+            local ver_comma="${ver//./ }"; ver_comma="${ver_comma// /,}"
+            sed -i "s/\(#define ${ver_macro}[[:space:]]\+\)[^[:space:]]*/\1${ver}/" "$FILE"
+            [ -n "$file_macro" ] && \
+              sed -i "s/\(#define ${file_macro}[[:space:]]\+\)[^[:space:]]*/\1${ver_comma}/" "$FILE"
+            echo "  ${ver_macro} -> ${ver}"
+          }
 
-          # Update QCOM_USB_DRIVERS_FILE_VERSION  (comma-separated)
-          sed -i "s/\(#define QCOM_USB_DRIVERS_FILE_VERSION\s\+\)[^[:space:]]*/\1${VERSION_COMMA_COMPACT}/" "$FILE"
+          echo "Updating $FILE:"
 
-          echo "Updated $FILE (relevant lines):"
-          grep -E "QCOM_USB_DRIVERS_(PRODUCT|FILE)_VERSION\b" "$FILE"
+          # Package-level version (always updated)
+          VERSION_COMMA="${VERSION//./ }"; VERSION_COMMA="${VERSION_COMMA// /,}"
+          sed -i "s/\(#define QCOM_USB_DRIVERS_PRODUCT_VERSION[[:space:]]\+\)[^ ]*/\1${VERSION}/" "$FILE"
+          sed -i "s/\(#define QCOM_USB_DRIVERS_FILE_VERSION[[:space:]]\+\)[^[:space:]]*/\1${VERSION_COMMA}/" "$FILE"
+          echo "  QCOM_USB_DRIVERS_PRODUCT_VERSION -> ${VERSION}"
 
-          # Verify
+          # Individual driver sub-versions (updated only when input is non-empty)
+          update_driver_ver "QCOM_FILTER_VERSION"    "QCOM_FILTER_FILE_VERSION"    "$FILTER_VER"
+          update_driver_ver "QCOM_NET_VERSION"       "QCOM_NET_FILE_VERSION"       "$NET_VER"
+          update_driver_ver "QCOM_WDFSERIAL_VERSION" "QCOM_WDFSERIAL_FILE_VERSION" "$WDFSERIAL_VER"
+          update_driver_ver "QCOM_QDSS_VERSION"      "QCOM_QDSS_FILE_VERSION"      "$QDSS_VER"
+          update_driver_ver "QCOM_ADB_VERSION"       ""                            "$ADB_VER"
+
+          echo ""
+          echo "Final version lines in $FILE:"
+          grep -E "_VERSION\b" "$FILE"
+
+          # Verify package version was applied
           grep -q "QCOM_USB_DRIVERS_PRODUCT_VERSION ${VERSION}" "$FILE" || \
             { echo "ERROR: PRODUCT_VERSION was not updated correctly"; exit 1; }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
     needs: validate
     if: needs.validate.outputs.do_linux == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
 
@@ -316,6 +317,7 @@ jobs:
     needs: validate
     if: needs.validate.outputs.do_windows == 'true'
     runs-on: ubuntu-latest   # branch/tag/release work; no WDK needed here
+    environment: release
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,10 @@ jobs:
     steps:
       - name: Check that at least one version was supplied
         id: check
+        env:
+          LNX: ${{ inputs.linux_version }}
+          WIN: ${{ inputs.windows_version }}
         run: |
-          LNX="${{ inputs.linux_version }}"
-          WIN="${{ inputs.windows_version }}"
-
           if [ -z "$LNX" ] && [ -z "$WIN" ]; then
             echo "ERROR: At least one of linux_version or windows_version must be provided."
             exit 1
@@ -116,8 +116,9 @@ jobs:
       # ── 1. Create release branch ──────────────────────────────────────────
       - name: Create release branch
         id: branch
+        env:
+          VERSION: ${{ inputs.linux_version }}
         run: |
-          VERSION="${{ inputs.linux_version }}"
           BRANCH="release-lnx-${VERSION}"
 
           if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
@@ -130,8 +131,9 @@ jobs:
 
       # ── 2. Bump version in version.h ──────────────────────────────────────
       - name: Update src/linux/version.h
+        env:
+          VERSION: ${{ inputs.linux_version }}
         run: |
-          VERSION="${{ inputs.linux_version }}"
           FILE="src/linux/version.h"
 
           sed -i "s/#define DRIVER_VERSION \".*\"/#define DRIVER_VERSION \"${VERSION}\"/" "$FILE"
@@ -145,14 +147,17 @@ jobs:
 
       # ── 3. Commit & push release branch ───────────────────────────────────
       - name: Commit version bump
+        env:
+          VERSION: ${{ inputs.linux_version }}
         run: |
-          VERSION="${{ inputs.linux_version }}"
           git add src/linux/version.h
           git commit -m "Update Linux driver version to ${VERSION}"
 
       - name: Push release branch
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
-          git push origin "${{ steps.branch.outputs.branch }}"
+          git push origin "$BRANCH"
 
       # ── 4. Build .deb package ─────────────────────────────────────────────
       - name: Install build dependencies
@@ -170,8 +175,9 @@ jobs:
       # ── 5. Package release artifact ───────────────────────────────────────
       - name: Create release zip
         id: zip
+        env:
+          VERSION: ${{ inputs.linux_version }}
         run: |
-          VERSION="${{ inputs.linux_version }}"
           DIR_NAME="qud_${VERSION}_all"
           ZIP_NAME="${DIR_NAME}.zip"
           DEB_FILE="src/linux/build/qud_${VERSION}_all.deb"
@@ -203,8 +209,9 @@ jobs:
       # ── 6. Create tag ─────────────────────────────────────────────────────
       - name: Create and push tag
         id: tag
+        env:
+          VERSION: ${{ inputs.linux_version }}
         run: |
-          VERSION="${{ inputs.linux_version }}"
           TAG="release-lnx-v${VERSION}"
 
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
@@ -220,34 +227,38 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.linux_version }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+          IS_DRAFT: ${{ inputs.draft }}
+          ZIP_PATH: ${{ steps.zip.outputs.zip_path }}
         run: |
-          VERSION="${{ inputs.linux_version }}"
-          TAG="${{ steps.tag.outputs.tag }}"
-          NOTES="${{ inputs.release_notes }}"
+          NOTES="$RELEASE_NOTES"
 
           if [ -z "$NOTES" ]; then
             NOTES="## Linux driver release v${VERSION}
 
-          Built from branch \`${{ steps.branch.outputs.branch }}\`.
+Built from branch \`${BRANCH}\`.
 
-          ### Installation
-          \`\`\`bash
-          sudo dpkg -i qud_${VERSION}_all.deb
-          \`\`\`
+### Installation
+\`\`\`bash
+sudo dpkg -i qud_${VERSION}_all.deb
+\`\`\`
 
-          ### Uninstall
-          \`\`\`bash
-          sudo dpkg -r qud
-          \`\`\`"
+### Uninstall
+\`\`\`bash
+sudo dpkg -r qud
+\`\`\`"
           fi
 
           DRAFT_FLAG=""
-          if [ "${{ inputs.draft }}" = "true" ]; then
+          if [ "$IS_DRAFT" = "true" ]; then
             DRAFT_FLAG="--draft"
           fi
 
           gh release create "$TAG" \
-            "${{ steps.zip.outputs.zip_path }}" \
+            "$ZIP_PATH" \
             --title "$TAG" \
             --notes "$NOTES" \
             $DRAFT_FLAG
@@ -294,8 +305,9 @@ jobs:
       # ── 1. Create release branch ──────────────────────────────────────────
       - name: Create release branch
         id: branch
+        env:
+          VERSION: ${{ inputs.windows_version }}
         run: |
-          VERSION="${{ inputs.windows_version }}"
           BRANCH="release-win-${VERSION}"
 
           if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
@@ -308,8 +320,9 @@ jobs:
 
       # ── 2. Bump version in qcversion.h ────────────────────────────────────
       - name: Update src/windows/qcversion.h
+        env:
+          VERSION: ${{ inputs.windows_version }}
         run: |
-          VERSION="${{ inputs.windows_version }}"
           # Convert dot-separated version to comma-separated for FILE_VERSION macros
           VERSION_COMMA="${VERSION//./, }"
           # Also produce the compact comma form used in the header (no spaces)
@@ -333,20 +346,24 @@ jobs:
 
       # ── 3. Commit & push release branch ───────────────────────────────────
       - name: Commit version bump
+        env:
+          VERSION: ${{ inputs.windows_version }}
         run: |
-          VERSION="${{ inputs.windows_version }}"
           git add src/windows/qcversion.h
           git commit -m "Update Windows driver version to ${VERSION}"
 
       - name: Push release branch
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
-          git push origin "${{ steps.branch.outputs.branch }}"
+          git push origin "$BRANCH"
 
       # ── 4. Create tag ─────────────────────────────────────────────────────
       - name: Create and push tag
         id: tag
+        env:
+          VERSION: ${{ inputs.windows_version }}
         run: |
-          VERSION="${{ inputs.windows_version }}"
           TAG="release-win-v${VERSION}"
 
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
@@ -362,20 +379,22 @@ jobs:
       - name: Create draft GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.windows_version }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
-          VERSION="${{ inputs.windows_version }}"
-          TAG="${{ steps.tag.outputs.tag }}"
-          NOTES="${{ inputs.release_notes }}"
+          NOTES="$RELEASE_NOTES"
 
           if [ -z "$NOTES" ]; then
             NOTES="## Windows driver release v${VERSION}
 
-          Built from branch \`${{ steps.branch.outputs.branch }}\`.
+Built from branch \`${BRANCH}\`.
 
-          > **Note:** Attach the signed build artifacts produced by the internal
-          > Windows build pipeline before publishing this release.
-          >
-          > Build locally with: \`.\build\build_drivers.ps1\` (requires Visual Studio + WDK)"
+> **Note:** Attach the signed build artifacts produced by the internal
+> Windows build pipeline before publishing this release.
+>
+> Build locally with: \`.\build\build_drivers.ps1\` (requires Visual Studio + WDK)"
           fi
 
           # Windows releases always start as draft because signed artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,11 +166,41 @@ jobs:
           sudo apt-get install -y --no-install-recommends dpkg-dev
 
       - name: Build deb package
+        id: build
         run: |
           cd src/linux
-          bash build-deb.sh
+          set -o pipefail
+          bash build-deb.sh 2>&1 | tee /tmp/build.log
           echo "Build output:"
           ls -lh build/
+
+      - name: Job summary
+        if: always()
+        env:
+          VERSION: ${{ inputs.linux_version }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          BUILD_RESULT: ${{ steps.build.outcome }}
+        run: |
+          {
+            echo "## Linux Release Summary — v${VERSION}"
+            echo ""
+            echo "| Step | Result |"
+            echo "|------|--------|"
+            echo "| Release branch | \`${BRANCH}\` |"
+            if [ "$BUILD_RESULT" = "success" ]; then
+              echo "| Build .deb | ✅ Success |"
+            else
+              echo "| Build .deb | ❌ **Failed** |"
+              echo ""
+              echo "### Build log"
+              echo "\`\`\`"
+              tail -50 /tmp/build.log 2>/dev/null || echo "(no log captured)"
+              echo "\`\`\`"
+              echo ""
+              echo "> **Action required:** Fix the build error, then re-run the workflow."
+              echo "> The release branch \`${BRANCH}\` has been pushed — delete it before re-running."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # ── 5. Package release artifact ───────────────────────────────────────
       - name: Create release zip
@@ -239,17 +269,17 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="## Linux driver release v${VERSION}
 
-Built from branch \`${BRANCH}\`.
+          Built from branch \`${BRANCH}\`.
 
-### Installation
-\`\`\`bash
-sudo dpkg -i qud_${VERSION}_all.deb
-\`\`\`
+          ### Installation
+          \`\`\`bash
+          sudo dpkg -i qud_${VERSION}_all.deb
+          \`\`\`
 
-### Uninstall
-\`\`\`bash
-sudo dpkg -r qud
-\`\`\`"
+          ### Uninstall
+          \`\`\`bash
+          sudo dpkg -r qud
+          \`\`\`"
           fi
 
           DRAFT_FLAG=""
@@ -389,12 +419,12 @@ sudo dpkg -r qud
           if [ -z "$NOTES" ]; then
             NOTES="## Windows driver release v${VERSION}
 
-Built from branch \`${BRANCH}\`.
+          Built from branch \`${BRANCH}\`.
 
-> **Note:** Attach the signed build artifacts produced by the internal
-> Windows build pipeline before publishing this release.
->
-> Build locally with: \`.\build\build_drivers.ps1\` (requires Visual Studio + WDK)"
+          > **Note:** Attach the signed build artifacts produced by the internal
+          > Windows build pipeline before publishing this release.
+          >
+          > Build locally with: \`.\build\build_drivers.ps1\` (requires Visual Studio + WDK)"
           fi
 
           # Windows releases always start as draft because signed artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,26 @@ jobs:
       do_linux: ${{ steps.check.outputs.do_linux }}
       do_windows: ${{ steps.check.outputs.do_windows }}
     steps:
+      - name: Check actor is a maintainer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          PERMISSION=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          echo "Actor '${ACTOR}' permission: ${PERMISSION}"
+          case "$PERMISSION" in
+            admin|maintain|write)
+              echo "✅ Authorized — proceeding with release."
+              ;;
+            *)
+              echo "ERROR: Only maintainers (write/maintain/admin) may trigger this workflow."
+              echo "Actor '${ACTOR}' has permission '${PERMISSION}'."
+              exit 1
+              ;;
+          esac
+
       - name: Check that at least one version was supplied
         id: check
         env:


### PR DESCRIPTION
This PR adds a GitHub Actions release workflow and a Windows build script to automate the release process for both Linux and Windows drivers.

## Changes

### `.github/workflows/release.yml`
A `workflow_dispatch` workflow triggered manually from the GitHub Actions UI. It accepts:

| Input | Description | Example |
|-------|-------------|---------|
| `linux_version` | Linux driver version to release | `1.0.6.5` |
| `windows_version` | Windows driver version to release | `1.00.94.6` |
| `filter_version` | Filter driver sub-version (optional) | `1.0.1.6` |
| `net_version` | NDIS/net driver sub-version (optional) | `5.0.1.2` |
| `wdfserial_version` | WDF serial driver sub-version (optional) | `1.0.3.7` |
| `qdss_version` | QDSS driver sub-version (optional) | `1.0.4.2` |
| `adb_version` | ADB driver sub-version (optional) | `1.0.1.7` |
| `base_branch` | Branch to cut the release from | `main` (default) |
| `release_notes` | Markdown release notes | _(auto-generated if empty)_ |
| `draft` | Create as draft release | `false` (default) |

Either or both of `linux_version` / `windows_version` can be supplied in a single run.

**Linux job** (fully automated on GitHub-hosted runner):
1. Creates release branch `release-lnx-{version}`
2. Updates `src/linux/version.h` with the new version
3. Commits and pushes the release branch
4. Builds the `.deb` package via `src/linux/build-deb.sh`
5. Packages the `.deb` + `RELEASES.md` + `README.md` into a zip
6. Creates annotated tag `release-lnx-v{version}`
7. Publishes the GitHub release with the zip as an artifact

**If the build fails:**
- The workflow run turns red in the **Actions** tab and GitHub sends an email notification to the person who triggered it
- A **Job Summary** is written to the workflow run page showing which step failed and the last 50 lines of the build log
- The summary also shows the release branch name and instructs the user to delete it before re-running

**Windows job** (branch/tag/release automation only — build is local):
1. Creates release branch `release-win-{version}`
2. Updates `src/windows/qcversion.h`:
   - `QCOM_USB_DRIVERS_PRODUCT_VERSION` is **always** updated to `windows_version`
   - Individual driver sub-versions are updated **only when the corresponding input is provided** (leave empty to keep the current value)
3. Commits and pushes the release branch
4. Creates annotated tag `release-win-v{version}`
5. Opens a **draft** GitHub release (signed build artifacts must be attached before publishing)

**Individual driver sub-version inputs (all optional):**

| Input | Driver | Macros updated in qcversion.h |
|-------|--------|-------------------------------|
| `filter_version` | Filter driver | `QCOM_FILTER_VERSION`, `QCOM_FILTER_FILE_VERSION` |
| `net_version` | NDIS/net driver | `QCOM_NET_VERSION`, `QCOM_NET_FILE_VERSION` |
| `wdfserial_version` | WDF serial driver | `QCOM_WDFSERIAL_VERSION`, `QCOM_WDFSERIAL_FILE_VERSION` |
| `qdss_version` | QDSS driver | `QCOM_QDSS_VERSION`, `QCOM_QDSS_FILE_VERSION` |
| `adb_version` | ADB driver | `QCOM_ADB_VERSION` |

### `build/build_drivers.ps1`
PowerShell build script for Windows drivers (requires Visual Studio + WDK on the build machine):
- Auto-detects MSBuild via `vswhere` and WDK via registry
- Builds filter, ndis, qdss, and wdfserial driver projects for x86, x64, and arm64
- Stamps INF file versions from `src/windows/qcversion.h`
- Generates catalog files via `inf2cat`
- Packages output to `build/target/Drivers/Windows10/`

## Release naming convention

| Platform | Branch | Tag |
|----------|--------|-----|
| Linux | `release-lnx-{version}` | `release-lnx-v{version}` |
| Windows | `release-win-{version}` | `release-win-v{version}` |

## Access control — only maintainers can trigger a release

The workflow enforces two independent gates:

**Gate 1 — Explicit permission check (in-workflow)**
The first step of the `validate` job calls the GitHub API to verify the triggering actor has `write`, `maintain`, or `admin` permission on the repository. If not, the workflow fails immediately with a clear error message before any branch or tag is created.

**Gate 2 — Environment protection (`environment: release`)**
Both release jobs use `environment: release`. When configured in **Settings → Environments** with required reviewers, the workflow pauses for explicit human approval even after the permission check passes.

**To configure the environment (repo admin, one-time setup):**
1. Go to **Settings → Environments → New environment**, name it `release`
2. Enable **Required reviewers** → add the maintainer team
3. Optionally enable **Prevent self-review**

If the `release` environment does not exist, Gate 1 (permission check) still enforces maintainer-only access.

## How to trigger a release

1. Go to **Actions → Release → Run workflow**
2. Fill in the version(s) and click **Run workflow**

For Linux-only release:
- `linux_version`: `1.0.6.7`
- `windows_version`: _(leave empty)_

For Windows-only release with sub-version bumps:
- `linux_version`: _(leave empty)_
- `windows_version`: `1.00.94.7`
- `adb_version`: `1.0.1.7`
- `filter_version`: `1.0.1.6`
- _(leave other sub-version inputs empty to keep current values)_

## Example: Linux release `1.0.6.5`

Triggered via workflow dispatch with `linux_version=1.0.6.5`:

1. Workflow created branch `release-lnx-1.0.6.5` and updated `src/linux/version.h`
2. Built `qud_1.0.6.5_all.deb` via `build-deb.sh` on a GitHub-hosted Ubuntu runner
3. Created tag `release-lnx-v1.0.6.5`
4. Published release with artifact `qud_1.0.6.5_all.zip`

Result: https://github.com/qualcomm/qcom-usb-kernel-drivers/releases/tag/release-lnx-v1.0.6.5

## Example: Windows release `1.00.94.6`

**Step 1 — Trigger workflow** with `windows_version=1.00.94.6`:
- Workflow created branch `release-win-1.00.94.6` and updated `src/windows/qcversion.h`
- Created tag `release-win-v1.00.94.6`
- Opened a **draft** GitHub release

**Step 2 — Build locally** on a Windows machine with Visual Studio 2019 + WDK:
```powershell
git clone https://github.com/qualcomm/qcom-usb-kernel-drivers.git
git checkout release-win-1.00.94.6
.\build\build_drivers.ps1
```

**Step 3 — Upload and publish**:
```powershell
# Zip the build output
Compress-Archive build\target\Drivers\Windows10 qud_1.00.94.6_windows.zip

# Upload to the draft release and publish
gh release upload release-win-v1.00.94.6 qud_1.00.94.6_windows.zip --repo qualcomm/qcom-usb-kernel-drivers
gh release edit release-win-v1.00.94.6 --draft=false --repo qualcomm/qcom-usb-kernel-drivers
```

Result: https://github.com/qualcomm/qcom-usb-kernel-drivers/releases/tag/release-win-v1.00.94.6

## Notes on Windows driver signing

The build script produces **test-signed** drivers (WDK auto-generates a `WDKTestCert` per machine). For production distribution, drivers must be submitted to [Microsoft Hardware Dev Center](https://partner.microsoft.com/dashboard/hardware) for **attestation signing** using an EV code-signing certificate. The `build/build_drivers.ps1` script includes a `Sign-File` helper that can be extended to support production signing.

## Test results

The complete workflow was tested on fork [`hangzqcom/qcom-usb-kernel-drivers`](https://github.com/hangzqcom/qcom-usb-kernel-drivers) after all changes were applied.

### Linux release `1.0.6.6` — [workflow run](https://github.com/hangzqcom/qcom-usb-kernel-drivers/actions/runs/26781733493)

| Job / Step | Result |
|------------|--------|
| Validate inputs | ✅ |
| → Check actor is a maintainer | ✅ |
| → Check version format | ✅ |
| Linux release 1.0.6.6 — Create release branch | ✅ |
| Linux release 1.0.6.6 — Update src/linux/version.h | ✅ |
| Linux release 1.0.6.6 — Build deb package | ✅ |
| Linux release 1.0.6.6 — Job summary | ✅ |
| Linux release 1.0.6.6 — Create release zip | ✅ |
| Linux release 1.0.6.6 — Create and push tag | ✅ |
| Linux release 1.0.6.6 — Create GitHub release | ✅ |
| Windows release | ⏭️ skipped (not requested) |

Published release: https://github.com/hangzqcom/qcom-usb-kernel-drivers/releases/tag/release-lnx-v1.0.6.6
Artifact: `qud_1.0.6.6_all.zip`

### Windows release `1.00.94.7` with sub-version bumps — [workflow run](https://github.com/hangzqcom/qcom-usb-kernel-drivers/actions/runs/26984442027)

Triggered with `windows_version=1.00.94.7`, `filter_version=1.0.1.6`, `adb_version=1.0.1.7`:

| Version macro | Before | After |
|---------------|--------|-------|
| `QCOM_USB_DRIVERS_PRODUCT_VERSION` | 1.00.94.6 | **1.00.94.7** |
| `QCOM_FILTER_VERSION` | 1.0.1.5 | **1.0.1.6** |
| `QCOM_ADB_VERSION` | 1.0.1.6 | **1.0.1.7** |
| `QCOM_NET_VERSION` | 5.0.1.1 | 5.0.1.1 (unchanged) |
| `QCOM_WDFSERIAL_VERSION` | 1.0.3.6 | 1.0.3.6 (unchanged) |
| `QCOM_QDSS_VERSION` | 1.0.4.1 | 1.0.4.1 (unchanged) |

Published draft release: https://github.com/hangzqcom/qcom-usb-kernel-drivers/releases/tag/release-win-v1.00.94.7

### Windows release `1.00.94.6` — tested previously

| Step | Result |
|------|--------|
| Workflow: create branch + tag + draft release | ✅ |
| Local build (`build_drivers.ps1`) | ✅ |
| Upload artifact + publish release | ✅ |

Published release: https://github.com/hangzqcom/qcom-usb-kernel-drivers/releases/tag/release-win-v1.00.94.6

## Security

All `${{ inputs.* }}` and `${{ steps.*.outputs.* }}` interpolations have been moved out of `run:` blocks into per-step `env:` sections to prevent shell injection (Semgrep `run-shell-injection` rule).