### PR TITLE
Optimize build and installer scripts for 1.00.94.6

### DIFF
--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,6 +1,5 @@
 param(
-    [string]$PayloadPath,
-    [string]$OutputPath
+    [string]$OutputName = "installer.exe"
 )
 
 # ==============================================================================
@@ -8,27 +7,15 @@ param(
 # ==============================================================================
 
 $Script:OutputRoot   = Join-Path $PSScriptRoot "target"
-$Script:DriversDir   = "Drivers"
-$Script:ToolsDir     = "Tools"
+$Script:DriversDir   = "drivers"
+$Script:ToolsDir     = "tools"
 $Script:PayloadName  = "payload.zip"
 $Script:VersionFile  = Join-Path $PSScriptRoot "..\src\windows\qcversion.h"
 
-# Files to promote from Tools/ to the payload root (alongside Drivers/ and Tools/)
+# Files to promote from tools/ to the payload root (alongside drivers/ and tools/)
 $Script:PromotedTools = @("qdclr.exe", "qdinstall.exe")
 
-# ==============================================================================
-# Functions
-# ==============================================================================
-
-# Assembles a payload zip from target/Drivers and target/Tools.
-# Promoted tools (qdclr.exe, qdinstall.exe) are copied to the zip root.
-# Returns the full path to the generated payload zip.
-# Payload layout contract (must match expectations in the embedded C# installer):
-#   <zip root>/
-#     qdinstall.exe   <- promoted from Tools/; used as entry point by C# installer
-#     qdclr.exe       <- promoted from Tools/; used by qdinstall.exe -x
-#     Drivers/        <- INF files passed to pnputil
-#     Tools/          <- remaining tools copied to installPath
+# Assembles a payload zip from target/drivers and target/tools.
 function New-Payload {
     Write-Host "========================================"
     Write-Host " Packaging Payload"
@@ -38,11 +25,11 @@ function New-Payload {
     $toolsSource   = Join-Path $Script:OutputRoot $Script:ToolsDir
 
     if (-not (Test-Path $driversSource)) {
-        Write-Error "Drivers directory not found: $driversSource"
+        Write-Error "[ERROR] Drivers directory not found: $driversSource"
         exit 1
     }
     if (-not (Test-Path $toolsSource)) {
-        Write-Error "Tools directory not found: $toolsSource"
+        Write-Error "[ERROR] Tools directory not found: $toolsSource"
         exit 1
     }
 
@@ -51,17 +38,13 @@ function New-Payload {
     New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
 
     try {
-        # Copy Drivers/
-        $destDrivers = Join-Path $stagingDir $Script:DriversDir
-        Copy-Item -Path $driversSource -Destination $destDrivers -Recurse -Force
-        Write-Host "[COPY] $Script:DriversDir -> $destDrivers"
+        # Copy drivers/ and tools/ into the staging root
+        Copy-Item -Path $driversSource -Destination $stagingDir -Recurse -Force
+        Copy-Item -Path $toolsSource   -Destination $stagingDir -Recurse -Force
+        Write-Host "[COPY] $Script:DriversDir, $Script:ToolsDir -> $stagingDir"
 
-        # Copy Tools/
+        # Promote specified tools to staging root and remove from tools/
         $destTools = Join-Path $stagingDir $Script:ToolsDir
-        Copy-Item -Path $toolsSource -Destination $destTools -Recurse -Force
-        Write-Host "[COPY] $Script:ToolsDir -> $destTools"
-
-        # Promote specified tools to staging root and remove from Tools/
         foreach ($toolFile in $Script:PromotedTools) {
             $srcFile = Join-Path $destTools $toolFile
             if (Test-Path $srcFile) {
@@ -69,7 +52,7 @@ function New-Payload {
                 Remove-Item -Path $srcFile -Force
                 Write-Host "[PROMOTE] $toolFile -> payload root"
             } else {
-                Write-Warning "Promoted tool not found in Tools: $toolFile"
+                Write-Warning "[WARNING] Promoted tool not found in Tools: $toolFile"
             }
         }
 
@@ -83,9 +66,7 @@ function New-Payload {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $payloadZip)
 
-        $zipSize = (Get-Item $payloadZip).Length
-        Write-Host "[OK] Payload created: $payloadZip ($zipSize bytes)`n" -ForegroundColor Green
-
+        Write-Host "[OK] Payload created: $payloadZip`n" -ForegroundColor Green
         return $payloadZip
     }
     finally {
@@ -100,17 +81,8 @@ function New-Payload {
 # Main Logic
 # ==============================================================================
 
-# --- Resolve payload ---
-if (-not $PayloadPath) {
-    $PayloadPath = New-Payload
-}
-
-if (-not (Test-Path $PayloadPath)) {
-    Write-Error "Payload file not found: $PayloadPath"
-    exit 1
-}
-
-$PayloadFullPath = (Resolve-Path $PayloadPath).Path
+# --- Build payload ---
+$PayloadFullPath = (Resolve-Path (New-Payload)).Path
 
 # --- Parse version ---
 $Version = "1.0.0.0"
@@ -123,7 +95,7 @@ if (Test-Path $Script:VersionFile) {
         Write-Warning "QCOM_USB_DRIVERS_PRODUCT_VERSION not found in $($Script:VersionFile), using default: $Version"
     }
 } else {
-    Write-Warning "Version file not found: $($Script:VersionFile), using default: $Version"
+    Write-Warning "[WARNING] Version file not found: $($Script:VersionFile), using default: $Version"
 }
 
 # C# source code for the installer
@@ -133,10 +105,9 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
-using Microsoft.Win32;
 
-[assembly: AssemblyTitle("Qualcomm USB Driver Installer")]
-[assembly: AssemblyDescription("Qualcomm USB Driver Installer")]
+[assembly: AssemblyTitle("Qualcomm USB Kernel Driver Installer")]
+[assembly: AssemblyDescription("Qualcomm USB Kernel Driver Installer")]
 [assembly: AssemblyCompany("Qualcomm Technologies, Inc.")]
 [assembly: AssemblyProduct("Qualcomm USB Kernel Drivers")]
 [assembly: AssemblyCopyright("Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.")]
@@ -148,54 +119,19 @@ namespace PayloadInstaller
 {
     class Program
     {
-        static readonly string UninstallRegKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Qualcomm USB Drivers";
+        // Fixed install location.
+        static readonly string InstallPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            "Qualcomm", "Qualcomm USB Drivers");
 
-        static string[] packages = {
+        static readonly string QdinstallExe = Path.Combine(InstallPath, "qdinstall.exe");
+
+        static readonly string[] LegacyPackages = {
             "qualcomm_userspace_driver",
             "qud",
             "qud.slt",
             "qud.internal"
         };
-
-        static void CopyDirectory(string sourceDir, string destDir)
-        {
-            Directory.CreateDirectory(destDir);
-            foreach (string file in Directory.GetFiles(sourceDir))
-            {
-                string destFile = Path.Combine(destDir, Path.GetFileName(file));
-                File.Copy(file, destFile, true);
-            }
-            foreach (string dir in Directory.GetDirectories(sourceDir))
-            {
-                string destSubDir = Path.Combine(destDir, Path.GetFileName(dir));
-                CopyDirectory(dir, destSubDir);
-            }
-        }
-
-        static int ElevateIfNeeded(string[] args)
-        {
-            var principal = new System.Security.Principal.WindowsPrincipal(
-                System.Security.Principal.WindowsIdentity.GetCurrent());
-            if (principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator))
-                return -1; // Already running as admin
-
-            ProcessStartInfo elevate = new ProcessStartInfo();
-            elevate.FileName = Assembly.GetExecutingAssembly().Location;
-            elevate.Arguments = string.Join(" ", args);
-            elevate.UseShellExecute = true;
-            elevate.Verb = "runas";
-            try
-            {
-                Process proc = Process.Start(elevate);
-                proc.WaitForExit();
-                return proc.ExitCode;
-            }
-            catch (Exception)
-            {
-                Console.Error.WriteLine("Error: Administrator privileges required.");
-                return 1;
-            }
-        }
 
         static int RunCommand(string fileName, string arguments)
         {
@@ -217,11 +153,95 @@ namespace PayloadInstaller
             }
         }
 
+        // Uninstall any previous installation.
+        static int Uninstall()
+        {
+            // Best-effort cleanup of legacy packages
+            foreach (string pkg in LegacyPackages)
+            {
+                Console.WriteLine("\nUninstalling legacy product: " + pkg + "...");
+                RunCommand("qpm-cli", "--uninstall " + pkg + " --silent");
+                RunCommand("qsc-cli", "tool uninstall -n " + pkg);
+            }
+
+            int result = 0;
+            if (File.Exists(QdinstallExe))
+            {
+                Console.WriteLine("\nRunning uninstaller: " + QdinstallExe);
+                result = RunCommand(QdinstallExe, "-x");
+            }
+
+            if (Directory.Exists(InstallPath))
+            {
+                try
+                {
+                    Directory.Delete(InstallPath, true);
+                }
+                catch (IOException ex)
+                {
+                    Console.Error.WriteLine("Warning: failed to delete " + InstallPath + ": " + ex.Message);
+                }
+            }
+
+            if (result == 0)
+                Console.WriteLine("\nUninstall completed successfully.");
+            else
+                Console.Error.WriteLine("\nUninstall failed with exit code: " + result);
+
+            return result;
+        }
+
+        // Install drivers and remove previous installation
+        static int Install()
+        {
+            Uninstall();
+
+            try
+            {
+                Directory.CreateDirectory(InstallPath);
+
+                // Stream-extract embedded payload directly into InstallPath
+                Console.WriteLine("\nExtracting payload to: " + InstallPath);
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                using (Stream resourceStream = assembly.GetManifestResourceStream("__PAYLOAD_NAME__"))
+                {
+                    if (resourceStream == null)
+                    {
+                        Console.Error.WriteLine("Error: Embedded payload resource not found.");
+                        return 1;
+                    }
+                    using (ZipArchive archive = new ZipArchive(resourceStream, ZipArchiveMode.Read))
+                    {
+                        archive.ExtractToDirectory(InstallPath);
+                    }
+                }
+                Console.WriteLine("Extraction complete.");
+
+                Console.WriteLine("\nRunning installer...");
+                int result = RunCommand(QdinstallExe, "-i -p \"" + InstallPath + "\"");
+
+                if (result == 0)
+                {
+                    Console.WriteLine("\nInstall completed successfully.");
+                }
+                else
+                {
+                    Console.Error.WriteLine("\nInstall failed with exit code: " + result);
+                    Console.Error.WriteLine("Install files preserved at: " + InstallPath);
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("Error: " + ex.Message);
+                return 1;
+            }
+        }
+
         static int Main(string[] args)
         {
             // Parse arguments
             string mode = "install"; // default (no args)
-
             if (args.Length > 0)
             {
                 string arg = args[0];
@@ -248,167 +268,46 @@ namespace PayloadInstaller
                 return 0;
             }
 
-            // Self-elevate if not running as administrator
-            int elevateResult = ElevateIfNeeded(args);
-            if (elevateResult >= 0)
-                return elevateResult;
-
             if (mode == "uninstall")
             {
-                // Read install location from registry
-                string uninstallPath = null;
-                using (var key = Registry.LocalMachine.OpenSubKey(UninstallRegKey))
-                {
-                    if (key != null)
-                        uninstallPath = key.GetValue("InstallLocation") as string;
-                }
-
-                if (string.IsNullOrEmpty(uninstallPath))
-                {
-                    Console.Error.WriteLine("Error: Cannot find installation from registry.");
-                    return 1;
-                }
-
-                // Run qdinstall.exe -x from the install location
-                string qdinstallExe = Path.Combine(uninstallPath, "qdinstall.exe");
-                Console.WriteLine("Running uninstaller: " + qdinstallExe);
-                int result = RunCommand(qdinstallExe, "-x");
-
-                // Delete install directory on success
-                if (result == 0 && !string.IsNullOrEmpty(uninstallPath) && Directory.Exists(uninstallPath))
-                {
-                    Directory.Delete(uninstallPath, true);
-                    Console.WriteLine("Deleted install directory: " + uninstallPath);
-                    Console.WriteLine("\nUninstall completed successfully.");
-                }
-                else if (result != 0)
-                {
-                    Console.Error.WriteLine("\nUninstall failed with exit code: " + result);
-                }
-                return result;
+                return Uninstall();
             }
 
-            // Install mode
-            string installPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-                "Qualcomm", "Qualcomm USB Drivers");
-
-            if (!Directory.Exists(installPath))
-                Directory.CreateDirectory(installPath);
-
-            // Extract embedded payload to temp directory
-            string tempDir = null;
-            try
-            {
-                tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("B").ToUpper());
-                string tempZip = Path.Combine(tempDir, "payload.zip");
-
-                Console.WriteLine("Extracting payload to: " + tempDir);
-
-                Assembly assembly = Assembly.GetExecutingAssembly();
-                using (Stream resourceStream = assembly.GetManifestResourceStream("Payload.zip"))
-                {
-                    if (resourceStream == null)
-                    {
-                        Console.Error.WriteLine("Error: Embedded payload resource not found.");
-                        return 1;
-                    }
-
-                    Directory.CreateDirectory(tempDir);
-                    using (FileStream fileStream = new FileStream(tempZip, FileMode.Create, FileAccess.Write))
-                    {
-                        resourceStream.CopyTo(fileStream);
-                    }
-                }
-
-                ZipFile.ExtractToDirectory(tempZip, tempDir);
-                File.Delete(tempZip);
-                Console.WriteLine("Extraction complete.");
-
-                // Uninstall legacy packages first (silent to avoid interactive UI)
-                foreach (string pkg in packages)
-                {
-                    Console.WriteLine("\nUninstalling legacy product: " + pkg + "...");
-                    RunCommand("qpm-cli", "--uninstall " + pkg + " --silent");
-                }
-
-                // Copy files to install path BEFORE registering, so that if the
-                // copy fails the registry is never written and no rollback is needed.
-                Console.WriteLine("Copying files to: " + installPath);
-                try { Directory.Delete(installPath, true); } catch { }
-                Directory.CreateDirectory(installPath);
-                CopyDirectory(tempDir, installPath);
-
-                // Verify qdinstall.exe is present in the payload root
-                // (see payload layout contract in build-installer.ps1: New-Payload)
-                string qdinstallPath = Path.Combine(tempDir, "qdinstall.exe");
-                if (!File.Exists(qdinstallPath))
-                {
-                    Console.Error.WriteLine("Error: qdinstall.exe not found in payload root.");
-                    Console.Error.WriteLine("       Expected at: " + qdinstallPath);
-                    return 1;
-                }
-
-                // Run qdinstall to register the installation (files are now in place)
-                Console.WriteLine("\nRunning installer...");
-                int result = RunCommand(qdinstallPath, "-i -p \"" + installPath + "\"");
-
-                if (result == 0)
-                {
-                    Console.WriteLine("\nInstall completed successfully.");
-                }
-                else
-                {
-                    Console.Error.WriteLine("\nInstall failed with exit code: " + result);
-                    // Rollback: remove install directory since registration failed
-                    try { Directory.Delete(installPath, true); }
-                    catch (Exception ex) { Console.Error.WriteLine("Warning: rollback failed: " + ex.Message); }
-                }
-                return result;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine("Error: " + ex.Message);
-                return 1;
-            }
-            finally
-            {
-                if (tempDir != null && Directory.Exists(tempDir))
-                {
-                    Directory.Delete(tempDir, true);
-                }
-            }
+            return Install();
         }
     }
 }
 '@
 
 # --- Resolve output exe path ---
-$DefaultExeName = "QUD_Installer.exe"
-if (-not $OutputPath) {
-    $outputExe = Join-Path $PSScriptRoot $DefaultExeName
-} elseif (Test-Path $OutputPath -PathType Container) {
-    $outputExe = Join-Path $OutputPath $DefaultExeName
-} elseif ($OutputPath -match '\.[^\\\/]+$') {
-    # Has extension - treat as full file path
-    $outputExe = $OutputPath
-    $outputDir = Split-Path $outputExe -Parent
-    if ($outputDir -and -not (Test-Path $outputDir)) {
-        New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
-    }
-} else {
-    # No extension - treat as directory
-    if (-not (Test-Path $OutputPath)) {
-        New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
-    }
-    $outputExe = Join-Path $OutputPath $DefaultExeName
+# OutputName must be a bare file name. The exe is always written to OutputRoot.
+if ($OutputName -match '[\\/]' -or [System.IO.Path]::IsPathRooted($OutputName)) {
+    Write-Error "[ERROR] OutputName must be a bare file name: $OutputName"
+    exit 1
 }
+$outputExe = Join-Path $Script:OutputRoot $OutputName
 
 # Write C# source to a temp file in the system temp directory
 $sourceFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.cs')
-
 $csharpSource = $csharpSource.Replace("__VERSION__", $Version)
+$csharpSource = $csharpSource.Replace("__PAYLOAD_NAME__", $Script:PayloadName)
 Set-Content -Path $sourceFile -Value $csharpSource -Encoding UTF8
+
+# Generate the application manifest (requireAdministrator).
+$manifestSource = @'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>
+'@
+$manifestFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.manifest')
+Set-Content -Path $manifestFile -Value $manifestSource -Encoding UTF8
 
 # Locate csc.exe: probe Framework64 first, then Framework, then PATH
 $cscPath = $null
@@ -423,7 +322,7 @@ if (-not $cscPath) {
     if ($cscCmd) { $cscPath = $cscCmd.Source }
 }
 if (-not $cscPath) {
-    Write-Error "csc.exe not found. Please install .NET Framework 4.x."
+    Write-Error "[ERROR] csc.exe not found. Please install .NET Framework 4"
     exit 1
 }
 
@@ -435,7 +334,8 @@ Write-Host "  Output:  $outputExe"
 $cscArgs = @(
     "/target:exe",
     "/out:$outputExe",
-    "/resource:$PayloadFullPath,Payload.zip",
+    "/win32manifest:$manifestFile",
+    "/resource:$PayloadFullPath,$($Script:PayloadName)",
     "/reference:System.IO.Compression.dll",
     "/reference:System.IO.Compression.FileSystem.dll",
     $sourceFile
@@ -444,10 +344,14 @@ $cscArgs = @(
 & $cscPath $cscArgs
 
 $buildExitCode = $LASTEXITCODE
-if (Test-Path $sourceFile) { Remove-Item $sourceFile -Force }
-if ($buildExitCode -eq 0) {
-    Write-Host "Build successful: $outputExe" -ForegroundColor Green
-} else {
-    Write-Error "Build failed with exit code: $buildExitCode"
+if (Test-Path $sourceFile)   { Remove-Item $sourceFile -Force }
+if (Test-Path $manifestFile) { Remove-Item $manifestFile -Force }
+if ($buildExitCode -eq 0)
+{
+    Write-Host "[OK] Build completed successfully: $outputExe" -ForegroundColor Green
+    Write-Host ""
+} else
+{
+    Write-Error "[ERROR] Build failed with exit code: $buildExitCode"
     exit $buildExitCode
 }

--- a/build/build_drivers.bat
+++ b/build/build_drivers.bat
@@ -2,7 +2,7 @@
 setlocal
 
 set "SCRIPT_DIR=%~dp0"
-set "BUILD_ROOT=%SCRIPT_DIR%\target"
+set "BUILD_ROOT=%SCRIPT_DIR%target"
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\build_drivers.ps1" -OutputTo "%BUILD_ROOT%"
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%

--- a/build/build_drivers.ps1
+++ b/build/build_drivers.ps1
@@ -53,10 +53,6 @@ $Script:WDKTools = @{
     "signtool.exe"  = $null
 }
 
-# Test signing (signtool) configuration
-$Script:EnableTestSign   = $false
-$Script:TestCertName     = "KmdfDriverTestCert"
-
 # Resolves a path to an absolute path.
 function Resolve-ScriptPath {
     param([Parameter(Mandatory)][string]$Path)
@@ -455,108 +451,6 @@ function Copy-DriverOutputs {
 }
 
 # ==============================================================================
-# Functions - Local Test Signing
-# ==============================================================================
-
-# Signs a single file using signtool.exe. Supports .cer or thumbprint.
-function Sign-File {
-    param(
-        [Parameter(Mandatory)][string]$FilePath,
-        [Parameter(Mandatory)][string]$Certificate
-    )
-
-    $signtool = $Script:WDKTools["signtool.exe"]
-    if (-not $signtool) {
-        Write-Host "[ERROR] signtool.exe not available." -ForegroundColor Red
-        return $false
-    }
-
-    $FilePath = Resolve-ScriptPath $FilePath
-    if (-not (Test-Path $FilePath)) {
-        Write-Host "[ERROR] File not found: $FilePath" -ForegroundColor Red
-        return $false
-    }
-
-    if ($Certificate -like "*.cer") {
-        $Certificate = Resolve-ScriptPath $Certificate
-        if (-not (Test-Path $Certificate)) {
-            Write-Host "[ERROR] Certificate file not found: $Certificate" -ForegroundColor Red
-            return $false
-        }
-        & $signtool sign /fd sha256 /f "$Certificate" "$FilePath" 2>&1 | Out-Host
-    } else {
-        & $signtool sign /fd sha256 /sha1 $Certificate /s My "$FilePath" 2>&1 | Out-Host
-    }
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "[ERROR] Failed to sign: $FilePath" -ForegroundColor Red
-        return $false
-    }
-
-    Write-Host "[OK] Signed: $(Split-Path $FilePath -Leaf)" -ForegroundColor Green
-    return $true
-}
-
-# Creates a temporary self-signed code-signing certificate, signs all .cat
-function Invoke-TestSign {
-    Write-Host "========================================"
-    Write-Host " Test Signing (signtool)"
-    Write-Host "========================================`n"
-
-    # --- Step 1: Validate output directory and .cat files ---
-    if (-not (Test-Path $OutputRoot)) {
-        Write-Host "[ERROR] Output directory not found: $OutputRoot" -ForegroundColor Red
-        return $false
-    }
-    $catFiles = Get-ChildItem $OutputRoot -Filter "*.cat" -File
-    if ($catFiles.Count -eq 0) {
-        Write-Host "[ERROR] No .cat files found in: $OutputRoot" -ForegroundColor Red
-        return $false
-    }
-    Write-Host "[SIGN] Found $($catFiles.Count) .cat file(s) to sign"
-    Write-Host ""
-
-    # --- Step 2: Create temporary certificate ---
-    Write-Host "[SIGN] Creating temporary test certificate..."
-    try {
-        $cert = New-SelfSignedCertificate `
-            -Type CodeSigningCert `
-            -Subject $Script:TestCertName `
-            -KeyAlgorithm RSA `
-            -KeyLength 2048 `
-            -KeyUsage DigitalSignature `
-            -CertStoreLocation "Cert:\CurrentUser\My" `
-            -NotAfter (Get-Date).AddDays(1)
-    } catch {
-        Write-Host "[ERROR] Failed to create test certificate: $($_.Exception.Message)" -ForegroundColor Red
-        return $false
-    }
-
-    $thumbprint = $cert.Thumbprint
-    Write-Host "[SIGN] Certificate: $($Script:TestCertName)"
-    Write-Host "[SIGN] Thumbprint:  $thumbprint"
-    Write-Host ""
-
-    # --- Step 3: Sign all .cat files, cleanup on exit ---
-    try {
-        foreach ($cat in $catFiles) {
-            if (-not (Sign-File -FilePath $cat.FullName -Certificate $thumbprint)) {
-                return $false
-            }
-            Write-Host ""
-        }
-    } finally {
-        Write-Host "[SIGN] Cleaning up temporary certificate..."
-        Remove-Item "Cert:\CurrentUser\My\$thumbprint" -Force -ErrorAction SilentlyContinue
-        Write-Host "[SIGN] Temporary certificate removed."
-    }
-
-    Write-Host ""
-    Write-Host "[OK] All .cat files are test-signed successfully." -ForegroundColor Green
-    return $true
-}
-
-# ==============================================================================
 # Main - Entry point: validates dependencies and builds drivers.
 # ==============================================================================
 
@@ -654,17 +548,6 @@ function Main {
     }
     Write-Host ""
 
-    # --- Step 9: Test signing (optional) ---
-    if ($Script:EnableTestSign) {
-        if (-not (Invoke-TestSign)) {
-            Write-Host "[ERROR] Test signing failed." -ForegroundColor Red
-            exit 1
-        }
-    } else {
-        Write-Host "[INFO] Test signing is disabled. Skipping." -ForegroundColor Yellow
-    }
-
-    Write-Host ""
     Write-Host "[OK] All build tasks completed successfully." -ForegroundColor Green
     Write-Host "[INFO] Output Location:"
     Write-Host "[INFO] $OutputRoot"

--- a/build/build_drivers.ps1
+++ b/build/build_drivers.ps1
@@ -10,14 +10,14 @@ param(
 
 $Script:VSWhereExe = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
 
-$Script:SourceRoot = "..\src\windows"  # Windows source directory, update when build folder moves
-$Script:OutputRoot = "target" # Directory for all output by default, use -OutputTo to override
-$Script:DriversDir = "Drivers\Windows10"
+$Script:SourceRoot = "..\src\windows"  # Windows driver source directory
+$Script:OutputRoot = "target"          # Default output directory, use -OutputTo to override
+$Script:DriversDir = "drivers"
 
 # Build configuration defaults
 $Script:BuildConfiguration = "Release"
 $Script:BuildPlatforms = @(
-    @{ Platform = "x86";   OutDir = "Win32"; CopyDir = "x86";  OSList = "10_X86" }
+    @{ Platform = "x86";   OutDir = "Win32"; CopyDir = "x86";   OSList = "10_X86" }
     @{ Platform = "x64";   OutDir = "x64";   CopyDir = "amd64"; OSList = "10_X64" }
     @{ Platform = "arm64"; OutDir = "arm64"; CopyDir = "arm64"; OSList = "10_RS4_ARM64,10_RS5_ARM64,10_19H1_ARM64,10_VB_ARM64" }
 )
@@ -43,7 +43,7 @@ $Script:InfVersionMap = @{
 # Inf2Cat OS targets (built dynamically from BuildPlatforms)
 $Script:Inf2CatOSList = ($Script:BuildPlatforms | ForEach-Object { $_.OSList }) -join ","
 
-# Tool paths (set manually or auto-detect at runtime)
+# Tool paths (auto-detect at runtime)
 $Script:MSBuildExe  = $null
 $Script:WDKRoot     = $null
 $Script:WDKVersion  = $null
@@ -242,7 +242,7 @@ function Build-AllDrivers {
 }
 
 # ==============================================================================
-# Functions - Inf Post-Processing
+# Functions - Post-Processing
 # ==============================================================================
 
 # Parses qcversion.h and returns a hashtable of { versionMacro, versionString }.
@@ -266,8 +266,7 @@ function Read-VersionFile {
 
     Write-Host "[VERSION] Parsed $($versions.Count) version(s) from: $FilePath"
     foreach ($key in $versions.Keys) {
-        $padded = $key.PadRight(32)
-        Write-Host "[VERSION] $padded = $($versions[$key])"
+        Write-Host "[VERSION] $($key.PadRight(32)) = $($versions[$key])"
     }
     return $versions
 }
@@ -326,9 +325,10 @@ function Run-StampInf {
         return $false
     }
 
-    $infFiles = Get-ChildItem -Path $OutputRoot -File -Filter "*.inf"
+    $destinationDir = Join-Path $OutputRoot $Script:DriversDir
+    $infFiles = Get-ChildItem -Path $destinationDir -File -Filter "*.inf"
     if (-not $infFiles) {
-        Write-Host "[WARN] No .inf files found in: $OutputRoot" -ForegroundColor Yellow
+        Write-Host "[WARN] No .inf files found in: $destinationDir" -ForegroundColor Yellow
         return $true
     }
 
@@ -365,9 +365,10 @@ function Run-Inf2Cat {
     Write-Host " OS targets: $Inf2CatOSList"
     Write-Host "========================================`n"
 
-    $infFiles = Get-ChildItem -Path $OutputRoot -File -Filter "*.inf"
+    $destinationDir = Join-Path $OutputRoot $Script:DriversDir
+    $infFiles = Get-ChildItem -Path $destinationDir -File -Filter "*.inf"
     if (-not $infFiles) {
-        Write-Host "[WARN] No .inf files found in: $OutputRoot" -ForegroundColor Yellow
+        Write-Host "[WARN] No .inf files found in: $destinationDir" -ForegroundColor Yellow
         return $false
     }
 
@@ -375,7 +376,7 @@ function Run-Inf2Cat {
         Write-Host "[INF2CAT] Found: $($inf.Name)"
     }
 
-    & $WDKTools["inf2cat.exe"] /driver:"$OutputRoot" /os:$Inf2CatOSList /uselocaltime 2>&1 | Out-Host
+    & $WDKTools["inf2cat.exe"] /driver:"$destinationDir" /os:$Inf2CatOSList /uselocaltime 2>&1 | Out-Host
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[ERROR] inf2cat failed with exit code: $LASTEXITCODE" -ForegroundColor Red
         return $false
@@ -386,10 +387,6 @@ function Run-Inf2Cat {
     return $true
 }
 
-# ==============================================================================
-# Functions - Output Collection
-# ==============================================================================
-
 # Copies .sys and .pdb files from build output to the output directory.
 function Copy-DriverOutputs {
     Write-Host "========================================"
@@ -397,7 +394,8 @@ function Copy-DriverOutputs {
     Write-Host "========================================`n"
 
     $hasError = $false
-    New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+    $driversDir = Join-Path $OutputRoot $Script:DriversDir
+    New-Item -ItemType Directory -Path $driversDir -Force | Out-Null
 
     foreach ($project in $DriverProjects) {
         if ($project.SolutionPath) {
@@ -410,7 +408,7 @@ function Copy-DriverOutputs {
                     continue
                 }
 
-                $destDir = Join-Path $OutputRoot "$($project.Name)\$($platformInfo.CopyDir)"
+                $destDir = Join-Path $driversDir "$($project.Name)\$($platformInfo.CopyDir)"
                 if (-not (Test-Path $destDir)) {
                     New-Item -ItemType Directory -Path $destDir -Force | Out-Null
                 }
@@ -428,13 +426,13 @@ function Copy-DriverOutputs {
             $projectDir = Resolve-ScriptPath "$SourceRoot\$($project.Name)"
         }
 
-        # Copy .inf files from the project directory to the output root
+        # Copy .inf files from the project directory to the drivers output directory
         $infFiles = Get-ChildItem -Path $projectDir -File -Filter "*.inf"
         foreach ($file in $infFiles) {
-            Copy-Item -Path $file.FullName -Destination $OutputRoot -Force
-            Write-Host "[COPY] $($file.Name) -> $OutputRoot"
+            Copy-Item -Path $file.FullName -Destination $driversDir -Force
+            Write-Host "[COPY] $($file.Name) -> $driversDir"
 
-            $destInf = Join-Path $OutputRoot $file.Name
+            $destInf = Join-Path $driversDir $file.Name
             if (-not (Update-Inf -InfPath $destInf -DriverName $project.Name)) {
                 $hasError = $true
             }
@@ -445,7 +443,7 @@ function Copy-DriverOutputs {
     if ($hasError) {
         Write-Host "[ERROR] Some driver outputs failed to copy or update." -ForegroundColor Red
     } else {
-        Write-Host "[OK] Driver outputs copied to: $OutputRoot" -ForegroundColor Green
+        Write-Host "[OK] Driver outputs copied to: $driversDir" -ForegroundColor Green
     }
     return (-not $hasError)
 }
@@ -462,10 +460,8 @@ function Main {
     if ($OutputTo) {
         $Script:OutputRoot = $OutputTo
     }
-    else {
-        $Script:OutputRoot = Resolve-ScriptPath $OutputRoot
-    }
-    $Script:OutputRoot = Join-Path $OutputRoot $DriversDir
+    $Script:OutputRoot        = Resolve-ScriptPath $Script:OutputRoot
+    $Script:SourceRoot        = Resolve-ScriptPath $Script:SourceRoot
     $Script:VersionHeaderFile = Resolve-ScriptPath $Script:VersionHeaderFile
 
     # --- Step 1: Locate MSBuild ---
@@ -521,9 +517,10 @@ function Main {
     Write-Host ""
 
     # --- Step 5: Clean output directory ---
-    if (-not $OutputTo -and (Test-Path $OutputRoot)) {
-        Remove-Item -Path $OutputRoot -Recurse -Force
-        Write-Host "[INFO] Cleaned output directory: $OutputRoot"
+    $cleanDir = Join-Path $OutputRoot $DriversDir
+    if (-not $OutputTo -and (Test-Path $cleanDir)) {
+        Remove-Item -Path $cleanDir -Recurse -Force
+        Write-Host "[INFO] Cleaned output directory: $cleanDir"
     }
     Write-Host ""
 
@@ -549,8 +546,7 @@ function Main {
     Write-Host ""
 
     Write-Host "[OK] All build tasks completed successfully." -ForegroundColor Green
-    Write-Host "[INFO] Output Location:"
-    Write-Host "[INFO] $OutputRoot"
+    Write-Host "[INFO] Output Location: $(Join-Path $OutputRoot $DriversDir)"
     Write-Host ""
 }
 

--- a/build/build_installer.bat
+++ b/build/build_installer.bat
@@ -4,16 +4,12 @@ setlocal enabledelayedexpansion
 set "SCRIPT_DIR=%~dp0"
 
 for %%A in (x86 x64 arm64) do (
-    echo ========================================
-    echo  Building for %%A
-    echo ========================================
-
     REM Build tools for this architecture
     powershell -ExecutionPolicy Bypass -File "%SCRIPT_DIR%build_tools.ps1" -Platform %%A
     if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!
 
     REM Build installer with arch-specific output name
-    powershell -ExecutionPolicy Bypass -File "%SCRIPT_DIR%build-installer.ps1" -OutputPath "%SCRIPT_DIR%target\qcom_usb_kernel_drivers_%%A.exe"
+    powershell -ExecutionPolicy Bypass -File "%SCRIPT_DIR%build-installer.ps1" -OutputName "qcom_usb_kernel_drivers_%%A.exe"
     if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!
 
     REM Sign the installer
@@ -23,12 +19,7 @@ for %%A in (x86 x64 arm64) do (
     )
 
     echo [DONE] %SCRIPT_DIR%target\qcom_usb_kernel_drivers_%%A.exe
-    echo.
 )
-
-echo ========================================
-echo  All installers built.
-echo ========================================
 
 endlocal
 exit /b 0

--- a/build/build_tools.ps1
+++ b/build/build_tools.ps1
@@ -13,9 +13,9 @@ param(
 
 $Script:VSWhereExe = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
 
-$Script:SourceRoot = "..\src\windows"  # Windows source directory, update when build folder moves
-$Script:OutputRoot = "target"           # Directory for all output by default
-$Script:ToolsDir   = "Tools"
+$Script:SourceRoot = "..\src\windows"  # Windows driver source directory
+$Script:OutputRoot = "target"          # Directory for all output by default
+$Script:ToolsDir   = "tools"           # Directory for all tools build output
 
 # Build configuration
 $Script:BuildConfiguration = "Release"
@@ -245,10 +245,6 @@ function Main {
     }
 
     # --- Summary ---
-    Write-Host "========================================"
-    Write-Host " Summary"
-    Write-Host "========================================`n"
-
     Write-Host "[OK] $successCount/$($ToolProjects.Count) tool(s) built successfully." -ForegroundColor Green
     Write-Host "[INFO] Output: $toolsOutputDir"
     Write-Host ""

--- a/build/sign.ps1
+++ b/build/sign.ps1
@@ -11,7 +11,7 @@ param(
 
 # Default input directory (relative to script root), used when -InputFrom is not specified
 $Script:DefaultInputRoot = "target"
-$Script:InputSubDir = "Drivers\Windows10"
+$Script:InputSubDir = "drivers"
 
 # Whether to recurse into subdirectories when scanning for signable files
 $Script:Recurse = $false

--- a/src/windows/tools/qdclr/infdev.cpp
+++ b/src/windows/tools/qdclr/infdev.cpp
@@ -307,7 +307,7 @@ BOOL DeviceMatch(PTSTR InfText, DWORD TextSize)
     {
         matchFound = TRUE;
     }
-	else if (StrStrW(InfText, TEXT("libusb-win32 devices")) != NULL)    // userspace (WinUSB)
+    else if (StrStrW(InfText, TEXT("libusb-win32 devices")) != NULL)    // userspace (WinUSB)
     {
         matchFound = TRUE;
     }

--- a/src/windows/tools/qdclr/qdclr.vcxproj
+++ b/src/windows/tools/qdclr/qdclr.vcxproj
@@ -86,14 +86,6 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>

--- a/src/windows/tools/qdinstall/main.cpp
+++ b/src/windows/tools/qdinstall/main.cpp
@@ -5,15 +5,14 @@
 #include "registry.h"
 #include "../../qcversion.h"
 
-constexpr const wchar_t *PATH_QDCLR    = L".\\qdclr.exe";
-constexpr const wchar_t *PATH_WWANSVC  = L".\\tools\\qcmtusvc.exe";
+constexpr const wchar_t *COMMAND_QDCLR    = L".\\qdclr.exe";
+constexpr const wchar_t *COMMAND_WWANSVC  = L".\\tools\\qcmtusvc.exe";
 #ifdef _WIN64
 constexpr const wchar_t *COMMAND_PNPUTIL_MAIN = L"pnputil /add-driver \"";
 #else
 constexpr const wchar_t *COMMAND_PNPUTIL_MAIN = L"C:\\Windows\\Sysnative\\pnputil.exe /add-driver \"";
 #endif
-constexpr const wchar_t *COMMAND_PNPUTIL_OPTS = L"\" /install /force";
-constexpr const wchar_t *PATH_INF_DIR         = L".\\Drivers\\Windows10\\";
+constexpr const wchar_t *COMMAND_PNPUTIL_OPTS = L"\" /subdirs /install /force";
 
 DWORD scan_for_hardware_changes()
 {
@@ -60,46 +59,29 @@ DWORD execute_command(const std::wstring &command)
     return ret;
 }
 
-DWORD install_drivers()
+DWORD install_drivers(const std::wstring &path)
 {
-    // Clean old drivers (best effort — ignore errors from qdclr)
-    printf("\nRemoving old drivers ...\n");
-    execute_command(PATH_QDCLR);
+    std::wstring cmd = COMMAND_PNPUTIL_MAIN;
+    cmd += path;
+    cmd += L"\\*.inf";
+    cmd += COMMAND_PNPUTIL_OPTS;
 
-    // Find and install each .inf in current directory
-    DWORD ret = ERROR_SUCCESS;
-    WIN32_FIND_DATAW fd;
-    std::wstring search_pattern = std::wstring(PATH_INF_DIR) + L"*.inf";
-    HANDLE hFind = FindFirstFileW(search_pattern.c_str(), &fd);
-
-    if (hFind == INVALID_HANDLE_VALUE)
+    printf("\nInstalling .inf from %ws ...\n", path.c_str());
+    DWORD ret = execute_command(cmd);
+    if (ret != ERROR_SUCCESS && ret != ERROR_SUCCESS_REBOOT_REQUIRED)
     {
-        printf("WARNING: no .inf files found in %ws\n", PATH_INF_DIR);
-        return ERROR_FILE_NOT_FOUND;
+        printf("ERROR: pnputil failed (exit code 0x%lX)\n", ret);
+        return ret;
     }
 
-    do {
-        std::wstring cmd = COMMAND_PNPUTIL_MAIN;
-        cmd += PATH_INF_DIR;
-        cmd += fd.cFileName;
-        cmd += COMMAND_PNPUTIL_OPTS;
-        printf("\nInstalling %ws ...\n", fd.cFileName);
-        if ((ret = execute_command(cmd)) != ERROR_SUCCESS)
-        {
-            printf("ERROR: pnputil failed for %ws (exit code 0x%lX)\n", fd.cFileName, ret);
-            FindClose(hFind);
-            return ret;
-        }
-    } while (FindNextFileW(hFind, &fd));
-
-    FindClose(hFind);
-    return scan_for_hardware_changes();
+    scan_for_hardware_changes();
+    return ERROR_SUCCESS;
 }
 
 DWORD uninstall_drivers()
 {
     printf("Removing drivers ...\n");
-    DWORD ret = execute_command(PATH_QDCLR);
+    DWORD ret = execute_command(COMMAND_QDCLR);
 
     if (ret == ERROR_FILE_NOT_FOUND)
     {
@@ -123,21 +105,21 @@ DWORD uninstall_drivers()
 
 static std::wstring get_exe_directory()
 {
-    std::wstring path(MAX_PATH, L'\0');
-    DWORD len = GetModuleFileNameW(NULL, &path[0], static_cast<DWORD>(path.size()));
-    path.resize(len);
-    size_t pos = path.find_last_of(L"\\/");
-    return (pos != std::wstring::npos) ? path.substr(0, pos) : L".";
+    WCHAR path[MAX_PATH];
+    GetModuleFileNameW(NULL, path, MAX_PATH);
+    PathRemoveFileSpecW(path);
+    return path[0] ? std::wstring(path) : std::wstring(L".");
 }
 
 static void inline print_usage()
 {
-    printf
-    (
+    printf(
         "Usage:\n"
-        "  qdinstall.exe -i\n"
-        "  qdinstall.exe -x\n"
-        "  qdinstall.exe -v\n"
+        "  qdinstall.exe [options]\n\n"
+        "Options:\n"
+        "  -i -p <path>   Install drivers from path\n"
+        "  -x             Uninstall drivers\n"
+        "  -v             Display version information\n"
     );
 }
 
@@ -243,16 +225,23 @@ int wmain(int argc, wchar_t *argv[])
 
     if (opts.install)
     {
-        ret = install_drivers();
+        // INF root: -p path if provided, otherwise the exe's own directory.
+        std::wstring inf_root = opts.installationPath.empty() ? exe_dir : opts.installationPath;
+        ret = install_drivers(inf_root);
         if (ret == ERROR_ACCESS_DENIED)
         {
             printf("ERROR: failed to install driver (admin required)\n");
             return ret;
         }
+        if (ret == ERROR_INVALID_NAME)
+        {
+            printf("ERROR: failed to install driver (invalid input path)\n");
+            return ret;
+        }
         if (ret == ERROR_NO_MORE_ITEMS)
         {
             printf("INFO: driver already installed for qualcomm usb devices\n");
-            return ret;
+            return ERROR_SUCCESS;
         }
         if (ret == ERROR_SUCCESS_REBOOT_REQUIRED)
         {
@@ -266,10 +255,10 @@ int wmain(int argc, wchar_t *argv[])
         }
 
         // Register and start WWAN service (best effort)
-        if (GetFileAttributesW(PATH_WWANSVC) != INVALID_FILE_ATTRIBUTES)
+        if (GetFileAttributesW(COMMAND_WWANSVC) != INVALID_FILE_ATTRIBUTES)
         {
             printf("\nRegistering WWAN service ...\n");
-            execute_command(std::wstring(PATH_WWANSVC) + L" install");
+            execute_command(std::wstring(COMMAND_WWANSVC) + L" install");
             printf("Starting WWAN service ...\n");
             execute_command(L"net start qcmtusvc");
         }
@@ -297,12 +286,12 @@ int wmain(int argc, wchar_t *argv[])
     else if (opts.uninstall)
     {
         // Stop and unregister WWAN service before driver removal
-        if (GetFileAttributesW(PATH_WWANSVC) != INVALID_FILE_ATTRIBUTES)
+        if (GetFileAttributesW(COMMAND_WWANSVC) != INVALID_FILE_ATTRIBUTES)
         {
             printf("Stopping WWAN service ...\n");
             execute_command(L"net stop qcmtusvc");
             printf("Unregistering WWAN service ...\n");
-            execute_command(std::wstring(PATH_WWANSVC) + L" uninstall");
+            execute_command(std::wstring(COMMAND_WWANSVC) + L" uninstall");
         }
 
         ret = uninstall_drivers();

--- a/src/windows/tools/qdinstall/main.h
+++ b/src/windows/tools/qdinstall/main.h
@@ -6,6 +6,7 @@
 #include <windows.h>
 #include <cfgmgr32.h>
 #include <string>
+#include <shlwapi.h>
 
 struct Options
 {
@@ -22,8 +23,8 @@ DWORD scan_for_hardware_changes();
 // Run an external process and wait for it to complete.
 DWORD execute_command(const std::wstring &command);
 
-// Install all .inf drivers from the current directory.
-DWORD install_drivers();
+// Install all .inf drivers under input path recursively.
+DWORD install_drivers(const std::wstring &path);
 
 // Uninstall drivers (run qdclr to clean DriverStore, then rescan).
 DWORD uninstall_drivers();

--- a/src/windows/tools/qdinstall/qdinstall.vcxproj
+++ b/src/windows/tools/qdinstall/qdinstall.vcxproj
@@ -125,7 +125,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -142,7 +142,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -155,7 +155,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -168,7 +168,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -185,7 +185,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -202,7 +202,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cfgmgr32.lib;advapi32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/windows/tools/qdinstall/registry.cpp
+++ b/src/windows/tools/qdinstall/registry.cpp
@@ -84,7 +84,7 @@ DWORD unregister_installation()
         RegCloseKey(hKey);
         return RegDeleteKeyExW(HKEY_LOCAL_MACHINE, uninstall_registry_key, KEY_WOW64_64KEY, 0);
     }
-    
+
     return (ret == ERROR_FILE_NOT_FOUND) ? ERROR_SUCCESS : ret;
 }
 

--- a/src/windows/tools/qdinstall/registry.h
+++ b/src/windows/tools/qdinstall/registry.h
@@ -19,7 +19,7 @@ struct InstallationInfo
     DWORD estimatedSizeKB = 0;
 };
 
-// Registration functions — return ERROR_SUCCESS (0) on success, Win32 error code on failure.
+// Registration functions - return ERROR_SUCCESS (0) on success, Win32 error code on failure.
 DWORD register_installation(const InstallationInfo &info);
 DWORD unregister_installation();
 bool is_installation_registered();


### PR DESCRIPTION

### Summary

- Sync build and installer files with the latest userspace driver changes
- Configure driver installer to request admin privileges by default
- Update installation path from `Drivers/Windows10/` to `drivers/`
- Enhance qdinstall project to handle additional error codes
- Remove test signing features from build scripts

### Test

- Verified with MSFT attestation signing and local installation