### PR TITLE
rmnet: fix PacketLen missing QMAP_UL_CHECKSUM size in QMAP header for V2/V3/V4

### DIFF
--- a/src/windows/ndis/MPUsb.c
+++ b/src/windows/ndis/MPUsb.c
@@ -4502,7 +4502,28 @@ VOID MPUSB_TLPTxPacket
             Qmap->PadCD |= (paddingBytes);
             Qmap->MuxId = pAdapter->MuxId;
             sendBytes += paddingBytes;
-            Qmap->PacketLen = RtlUshortByteSwap(sendBytes);
+            /* When QMAPEnabledV4/V2/V3 is active, the QMAP_UL_CHECKSUM structure
+             * (8 bytes) is placed between the QMAP header and the IP payload. The
+             * PacketLen field must cover all bytes that follow the QMAP header, so it
+             * must include sizeof(QMAP_UL_CHECKSUM).  Without this fix, PacketLen is
+             * undersized by sizeof(QMAP_UL_CHECKSUM); IPA advances its frame-boundary
+             * pointer sizeof(QMAP_UL_CHECKSUM) bytes early, misreads trailing IP
+             * payload as the next QMAP header, and raises exception=4
+             * (status.pkt_len < qmap.pkt_len). */
+            if ((pAdapter->QMAPEnabledV4 == TRUE)
+#ifdef QCUSB_MUX_PROTOCOL
+#if defined(QCMP_QMAP_V2_SUPPORT)
+                || (pAdapter->QMAPEnabledV2 == TRUE) || (pAdapter->QMAPEnabledV3 == TRUE)
+#endif
+#endif
+                )
+            {
+                Qmap->PacketLen = RtlUshortByteSwap((USHORT)(sendBytes + sizeof(QMAP_UL_CHECKSUM)));
+            }
+            else
+            {
+                Qmap->PacketLen = RtlUshortByteSwap((USHORT)sendBytes);
+            }
             if (pAdapter->QMAPEnabledV4 == TRUE)
             {
                 PQMAP_UL_CHECKSUM pULCheckSum = (PQMAP_UL_CHECKSUM)((PUCHAR)Qmap + sizeof(QMAP_STRUCT));
@@ -5798,7 +5819,28 @@ VOID MPUSB_TLPTxPacketEx
             Qmap->PadCD |= (paddingBytes);
             Qmap->MuxId = pAdapter->MuxId;
             sendBytes += paddingBytes;
-            Qmap->PacketLen = RtlUshortByteSwap(sendBytes);
+            /* When QMAPEnabledV4/V2/V3 is active, the QMAP_UL_CHECKSUM structure
+             * (8 bytes) is placed between the QMAP header and the IP payload. The
+             * PacketLen field must cover all bytes that follow the QMAP header, so it
+             * must include sizeof(QMAP_UL_CHECKSUM).  Without this fix, PacketLen is
+             * undersized by sizeof(QMAP_UL_CHECKSUM); IPA advances its frame-boundary
+             * pointer sizeof(QMAP_UL_CHECKSUM) bytes early, misreads trailing IP
+             * payload as the next QMAP header, and raises exception=4
+             * (status.pkt_len < qmap.pkt_len). */
+            if ((pAdapter->QMAPEnabledV4 == TRUE)
+#ifdef QCUSB_MUX_PROTOCOL
+#if defined(QCMP_QMAP_V2_SUPPORT)
+                || (pAdapter->QMAPEnabledV2 == TRUE) || (pAdapter->QMAPEnabledV3 == TRUE)
+#endif
+#endif
+                )
+            {
+                Qmap->PacketLen = RtlUshortByteSwap((USHORT)(sendBytes + sizeof(QMAP_UL_CHECKSUM)));
+            }
+            else
+            {
+                Qmap->PacketLen = RtlUshortByteSwap((USHORT)sendBytes);
+            }
             if (pAdapter->QMAPEnabledV4 == TRUE)
             {
                 PQMAP_UL_CHECKSUM pULCheckSum = (PQMAP_UL_CHECKSUM)((PUCHAR)Qmap + sizeof(QMAP_STRUCT));


### PR DESCRIPTION

## Summary

> Users observed QMAP header corruption, which is leading to the crash. 
> Ideally, the packet length in the status pointer should be greater than the length specified in the QMAP header.
>   (*(ipa_ul.curr_eot.curr_pkt.status_ptr)).exception = 4 = 0x4
>   (*(ipa_ul.curr_eot.curr_pkt.status_ptr)).pkt_len = 8 = 0x8


### Analysis
When QMAP V2/V3/V4 (UL checksum offload) is active, each uplink QMAP frame is laid out as:

```
[QMAP header (4B)] [QMAP_UL_CHECKSUM (8B)] [IP data + padding (N+P bytes)]
```

The `PacketLen` field in the QMAP header tells the device (IPA) where the next frame begins. It should equal everything after the QMAP header: `sizeof(QMAP_UL_CHECKSUM) + N + P`.

The driver was setting `PacketLen = N + P`, omitting `sizeof(QMAP_UL_CHECKSUM)`. This caused IPA's frame-boundary pointer to advance `sizeof(QMAP_UL_CHECKSUM)` bytes too early, so the trailing IP payload bytes were misread as the next QMAP header — producing a corrupt header and a crash:

```
IPA exception = 4
status.pkt_len = 8  <  qmap.pkt_len = 6746
```

### Fix

In `MPUSB_TLPTxPacket` and `MPUSB_TLPTxPacketEx` (`MPUsb.c`), add `sizeof(QMAP_UL_CHECKSUM)` to `PacketLen` when a UL checksum header is present:

```c
// Before
Qmap->PacketLen = RtlUshortByteSwap(sendBytes);

// After
if (QMAPEnabledV4 || QMAPEnabledV2 || QMAPEnabledV3)
    Qmap->PacketLen = RtlUshortByteSwap((USHORT)(sendBytes + sizeof(QMAP_UL_CHECKSUM)));
else
    Qmap->PacketLen = RtlUshortByteSwap((USHORT)sendBytes);  // V1: unchanged
```

### Files Changed

- `src/windows/ndis/MPUsb.c`


### Verification

Customer has confirmed the issue is not seen after this patch.

---