### PR TITLE
installer: copy binaries into payload without arch subfolder

### DIFF
--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -47,8 +47,8 @@ function New-Payload {
                     continue
                 }
                 New-Item -ItemType Directory -Path $destDir -Force | Out-Null
-                Copy-Item -Path $archSource -Destination $destDir -Recurse -Force
-                Write-Host "[COPY] $($item.Path)/$($item.Arch) -> staging"
+                Copy-Item -Path "$archSource\*" -Destination $destDir -Recurse -Force
+                Write-Host "[COPY] $($item.Path)/$($item.Arch)/* -> $($item.Path)/"
                 continue
             }
 


### PR DESCRIPTION
## Summary
Simplify the install path of non-driver payloads by removing the architecture subfolder from the final payload.

The old install path for `PayloadItems`:

```javascript
<InstallPath>\<PayloadRootDir>\<Arch>\*
```

The new installed layout becomes:

```javascript
<InstallPath>\<PayloadRootDir>\*
```

## Test
Verified with local build and installation