### PR TITLE
filter: fix absolute registry path access error in the Windows 11 26H1 HLK

### DIFF
--- a/src/windows/filter/qcfilter.c
+++ b/src/windows/filter/qcfilter.c
@@ -14,10 +14,13 @@ GENERAL DESCRIPTION
 
 *====*====*====*====*====*====*====*====*====*====*====*====*====*====*====*/
 
-#include "Ntddk.h"
-#include "Usbdi.h"
-#include "Usbdlib.h"
-#include <Ntstrsafe.h>
+#include <ntddk.h>
+#include <usbdi.h>
+#include <usbdlib.h>
+#include <ntstrsafe.h>
+#include <wdmsec.h>
+#include <initguid.h>
+#include <devpkey.h>
 
 #include "qcfilter.h"
 #include "qcfilterioc.h"
@@ -3464,13 +3467,15 @@ NTSTATUS QCFilterCreateFriendlyName
             RtlStringCbCatW(pDevExt->FriendlyNameHolder, MAX_NAME_LEN, RIGHT_P);
             RtlInitUnicodeString(&friendlyNameU, pDevExt->FriendlyNameHolder);
 
-            // Create FriendlyName in registry
-            nts = QCFilterSetFriendlyName
-            (
-                pDevExt,
+            // Set FriendlyName via PnP device property API
+            nts = IoSetDevicePropertyData(
                 QCPhysicalDeviceObject,
-                &friendlyNameU,
-                (PWCHAR)driverKey
+                &DEVPKEY_Device_FriendlyName,
+                LOCALE_NEUTRAL,
+                0,
+                DEVPROP_TYPE_STRING,
+                friendlyNameU.Length + sizeof(WCHAR),
+                friendlyNameU.Buffer
             );
         }
     }
@@ -3478,293 +3483,3 @@ NTSTATUS QCFilterCreateFriendlyName
     return nts;
 }  // QCFilterCreateFriendlyName
 
-/****************************************************************************
- *
- * function: QCFilterSetFriendlyName
- *
- * purpose:  Writes a FriendlyName registry value to the hardware key of the
- *           device whose SW driver key matches TargetDriverKey. Enumerates
- *           the hardware ID subkeys under HKLM\SYSTEM\...\Enum\<hwid> and
- *           sets the "FriendlyName" value in the matching subkey.
- *
- * arguments:pDevExt                = pointer to the filter device extension
- *           QCPhysicalDeviceObject = pointer to the physical device object
- *           FriendlyName           = pointer to the unicode friendly name string
- *           TargetDriverKey        = driver key name to match (e.g. "{GUID}\nnnn")
- *
- * returns:  NT status
- *
- ****************************************************************************/
-NTSTATUS QCFilterSetFriendlyName
-(
-    PDEVICE_EXTENSION pDevExt,
-    PDEVICE_OBJECT    QCPhysicalDeviceObject,
-    PUNICODE_STRING   FriendlyName,
-    PWCHAR            TargetDriverKey
-)
-{
-#define QC_NAME_LEN 1024
-#define DEVICE_HW_KEY_ROOT L"\\REGISTRY\\MACHINE\\SYSTEM\\CurrentControlSet\\Enum\\"
-    NTSTATUS        nts;
-    ULONG           bufLen, actualLen;
-    CHAR            hwId[QC_NAME_LEN], swKey[QC_NAME_LEN], devKey[QC_NAME_LEN];
-    PWCHAR          pId;
-    DWORD           idLen, restLen, subKeyIdx, subKeyLen;
-    int             selected = 0;
-    HANDLE          hwKeyHandle;
-    UNICODE_STRING  ucHwKeyPath;
-    OBJECT_ATTRIBUTES oa;
-
-    RtlZeroMemory(hwId, QC_NAME_LEN);
-    RtlZeroMemory(swKey, QC_NAME_LEN);
-    RtlZeroMemory(devKey, QC_NAME_LEN);
-
-    // get HW IDs
-    bufLen = QC_NAME_LEN;
-    nts = IoGetDeviceProperty
-    (
-        QCPhysicalDeviceObject,
-        DevicePropertyHardwareID,
-        bufLen,
-        (PVOID)hwId,
-        &actualLen
-    );
-    if (!NT_SUCCESS(nts))
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_ERROR,
-            ("<%s> QDBPNP_SetFriendlyName: IoGetDeviceProperty (HWID) failure\n", pDevExt->PortName)
-        );
-        return nts;
-    }
-    else
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_DETAIL,
-            ("<%s> QDBPNP_SetFriendlyName: IoGetDeviceProperty (HWID) len: %u\n", pDevExt->PortName, actualLen)
-        );
-    }
-    pId = (PWCHAR)hwId;
-    restLen = actualLen;
-
-    while ((idLen = wcsnlen(pId, restLen)) > 0)
-    {
-        if (idLen >= restLen) break;
-        selected = 1;
-        if (wcsstr(pId, L"REV_") != NULL)
-        {
-            selected = 0;
-        }
-        else
-        {
-            break;
-        }
-        pId += (idLen + 1); // including NULL
-        restLen -= (idLen + 1);
-    }
-    if (selected == 0)
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_DETAIL,
-            ("<%s> QDBPNP_SetFriendlyName: failed to find devID\n", pDevExt->PortName)
-        );
-        return STATUS_UNSUCCESSFUL;
-    }
-
-    // HW ID: pId, idLen
-    // construct full HW key
-    nts = RtlStringCbCopyW((PWCHAR)devKey, QC_NAME_LEN, DEVICE_HW_KEY_ROOT);
-    if (nts != STATUS_SUCCESS)
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_ERROR,
-            ("<%s> QDBPNP_SetFriendlyName: HW key root failure\n", pDevExt->PortName)
-        );
-        return nts;
-    }
-    nts = RtlStringCbCatW((PWCHAR)devKey, QC_NAME_LEN, pId);
-    if (nts != STATUS_SUCCESS)
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_ERROR,
-            ("<%s> QDBPNP_SetFriendlyName: RtlStringCbCat failed\n", pDevExt->PortName)
-        );
-        return nts;
-    }
-    QCFLT_DbgPrint
-    (
-        DBG_LEVEL_DETAIL,
-        ("<%s> QDBPNP_SetFriendlyName: devKey <%ws>\n", pDevExt->PortName, (PWCHAR)devKey)
-    );
-
-    // open HW key
-    RtlInitUnicodeString(&ucHwKeyPath, (PWCHAR)devKey);
-    InitializeObjectAttributes
-    (
-        &oa,
-        &ucHwKeyPath,
-        (OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE),
-        NULL, NULL
-    );
-    nts = ZwOpenKey
-    (
-        &hwKeyHandle,
-        GENERIC_ALL,
-        &oa
-    );
-    if (nts != STATUS_SUCCESS)
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_ERROR,
-            ("<%s> QDBPNP_SetFriendlyName: ZwOpenKey failed 0x%x\n", pDevExt->PortName, nts)
-        );
-        return nts;
-    }
-    // enum subkeys
-    subKeyIdx = 0;
-    while (nts == STATUS_SUCCESS)
-    {
-        CHAR           subKeyInfo[QC_NAME_LEN];
-        UNICODE_STRING ucSubKeyPath;
-        PKEY_BASIC_INFORMATION keyName;
-        OBJECT_ATTRIBUTES      oa;
-
-        RtlZeroMemory(subKeyInfo, QC_NAME_LEN);
-        nts = ZwEnumerateKey
-        (
-            hwKeyHandle,
-            subKeyIdx,
-            KeyBasicInformation,
-            (PVOID)subKeyInfo,
-            QC_NAME_LEN,
-            &subKeyLen
-        );
-        // open each subkey for R/W and find a match with SW key
-        if (nts == STATUS_SUCCESS)
-        {
-            HANDLE subKeyHandle;
-            CHAR   driverInfo[QC_NAME_LEN];
-            DWORD  infoLen;
-            UNICODE_STRING ucRegEntryName;
-
-            keyName = (PKEY_BASIC_INFORMATION)subKeyInfo;
-            QCFLT_DbgPrint
-            (
-                DBG_LEVEL_DETAIL,
-                ("<%s> QDBPNP_SetFriendlyName: subKey[%d]: <%ws>\n", pDevExt->PortName, subKeyIdx, keyName->Name)
-            );
-
-            RtlInitUnicodeString(&ucSubKeyPath, keyName->Name);
-            InitializeObjectAttributes
-            (
-                &oa,
-                &ucSubKeyPath,
-                (OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE),
-                hwKeyHandle,
-                NULL
-            );
-            nts = ZwOpenKey
-            (
-                &subKeyHandle,
-                GENERIC_ALL,
-                &oa
-            );
-            if (nts != STATUS_SUCCESS)
-            {
-                QCFLT_DbgPrint
-                (
-                    DBG_LEVEL_ERROR,
-                    ("<%s> QDBPNP_SetFriendlyName: ZwOpenKey failed (sub): 0x%x\n", pDevExt->PortName, nts)
-                );
-                break;
-            }
-
-            // retrieve driver key and match
-            RtlZeroMemory(driverInfo, QC_NAME_LEN);
-            RtlInitUnicodeString(&ucRegEntryName, L"Driver");
-            nts = ZwQueryValueKey
-            (
-                subKeyHandle,
-                &ucRegEntryName,
-                KeyValueFullInformation,
-                (PKEY_VALUE_FULL_INFORMATION)&driverInfo,
-                QC_NAME_LEN,
-                &infoLen
-            );
-            if (nts == STATUS_SUCCESS)
-            {
-                UNICODE_STRING swKey1, swKey2;
-                PKEY_VALUE_FULL_INFORMATION pDriverKey;
-                PCHAR pDrvKeyVal;
-
-                pDriverKey = (PKEY_VALUE_FULL_INFORMATION)&driverInfo;
-                pDrvKeyVal = (PCHAR)&driverInfo;
-                pDrvKeyVal += pDriverKey->DataOffset;
-                QCFLT_DbgPrint
-                (
-                    DBG_LEVEL_DETAIL,
-                    ("<%s> QDBPNP_SetFriendlyName: retrived %uB swKey <%ws>vs<%ws>\n", pDevExt->PortName,
-                    infoLen, (PWCHAR)pDrvKeyVal, TargetDriverKey)
-                );
-                RtlInitUnicodeString(&swKey1, TargetDriverKey);
-                RtlInitUnicodeString(&swKey2, (PWCHAR)pDrvKeyVal);
-                if (TRUE == RtlEqualUnicodeString(&swKey1, &swKey2, TRUE))
-                {
-                    UNICODE_STRING ucSetEntryName;
-
-                    // set FriendlyName
-                    RtlInitUnicodeString(&ucSetEntryName, L"FriendlyName");
-                    nts = ZwSetValueKey
-                    (
-                        subKeyHandle,
-                        &ucSetEntryName,
-                        0,
-                        REG_SZ,
-                        FriendlyName->Buffer,
-                        FriendlyName->Length + 2
-                    );
-                    if (!NT_SUCCESS(nts))
-                    {
-                        QCFLT_DbgPrint
-                        (
-                            DBG_LEVEL_ERROR,
-                            ("<%s> QDBPNP_SetFriendlyName: failed to set FriendlyName: 0x%x\n", pDevExt->PortName, nts)
-                        );
-                    }
-                }
-            }
-            else
-            {
-                QCFLT_DbgPrint
-                (
-                    DBG_LEVEL_ERROR,
-                    ("<%s> QDBPNP_SetFriendlyName: ZwQueryValueKey (swKey) failure 0x%x\n", pDevExt->PortName, nts)
-                );
-            }
-            ZwClose(subKeyHandle);
-        }
-        else
-        {
-            QCFLT_DbgPrint
-            (
-                DBG_LEVEL_ERROR,
-                ("<%s> QDBPNP_SetFriendlyName: ZwEnumerateKey failed/exhausted 0x%x\n", pDevExt->PortName, nts)
-            );
-            if (nts == STATUS_NO_MORE_ENTRIES)
-            {
-                nts = STATUS_SUCCESS;
-            }
-            break;
-        }
-        subKeyIdx++;
-    }  // while
-    ZwClose(hwKeyHandle);
-
-    return nts;
-}  // QCFilterSetFriendlyName

--- a/src/windows/filter/qcfilter.c
+++ b/src/windows/filter/qcfilter.c
@@ -14,18 +14,10 @@ GENERAL DESCRIPTION
 
 *====*====*====*====*====*====*====*====*====*====*====*====*====*====*====*/
 
-#include <stdio.h>
-#include <stdlib.h>
-////////////////////////////////////////////////////////////
-// WDK headers defined here
-//
 #include "Ntddk.h"
 #include "Usbdi.h"
 #include "Usbdlib.h"
-#include "Usbioctl.h"
-#include "Wdm.h"
 #include <Ntstrsafe.h>
-#include <string.h>
 
 #include "qcfilter.h"
 #include "qcfilterioc.h"
@@ -36,12 +28,10 @@ GENERAL DESCRIPTION
 #endif
 
 KEVENT ControlLock;
-ULONG InstanceCount = (ULONG)0;
 
 // To store the device name
 char gDeviceName[255];
 ULONG gDeviceIndex;
-ULONG gMuxDeviceIndex = (ULONG)NUM_START_INTERFACEID;
 
 LIST_ENTRY Control_DeviceList;
 KSPIN_LOCK Control_DeviceLock;
@@ -65,15 +55,10 @@ DriverEntry(PDRIVER_OBJECT  driverObject, PUNICODE_STRING registryPath)
     NTSTATUS            status = STATUS_SUCCESS;
     ULONG               ulIndex;
     PDRIVER_DISPATCH *dispatch;
-    ULONG i;
     ANSI_STRING asDevName;
     char *p;
 
 #ifdef EVENT_TRACING
-    //
-    // include this to support WPP.
-    //
-
     // This macro is required to initialize software tracing.
     WPP_INIT_TRACING(driverObject, registryPath);
 #endif
@@ -1075,15 +1060,12 @@ NTSTATUS QCFLT_CallUSBD
 
     IoCompleteRequest(irp, IO_NO_INCREMENT);
 
-ExitCallUSBD:
-
     if (ntStatus == STATUS_TIMEOUT)
     {
         ntStatus = STATUS_UNSUCCESSFUL;
     }
 
     return ntStatus;
-
 }  // QCUSB_CallUSBD
 
 /****************************************************************************
@@ -2358,9 +2340,6 @@ QCFLT_IsIrpInQueue(PDEVICE_EXTENSION pDevExt, PLIST_ENTRY Queue, PIRP Irp)
     PLIST_ENTRY headOfList, peekEntry;
     PIRP pIrp;
     BOOLEAN bInQueue = FALSE;
-    PCHAR pcIrpName;
-    KIRQL levelOrHandle;
-
 
     QCFLT_DbgPrint
     (
@@ -3120,12 +3099,10 @@ VOID QCFLT_PrintBytes
     ULONG DbgLevel
 )
 {
-    ULONG nWritten;
     char *buf, *p, *cBuf, *cp;
     char *buffer;
     ULONG count = 0, lastCnt = 0, spaceNeeded;
     ULONG i, j, s;
-    ULONG nts;
     PCHAR dbgOutputBuffer;
     ULONG myTextSize = 1280;
     PDEVICE_EXTENSION pDevExt = x;
@@ -3319,51 +3296,6 @@ BOOLEAN USBPNP_ValidateConfigDescriptor
 
 /****************************************************************************
  *
- * function: USBPNP_ValidateDeviceDescriptor
- *
- * purpose:  Validates the basic fields of a USB device descriptor to ensure
- *           it is well-formed before the driver processes it further.
- *
- * arguments:pDevExt  = pointer to the filter device extension (for logging)
- *           DevDesc  = pointer to the USB device descriptor to validate
- *
- * returns:  TRUE if the descriptor is valid; FALSE otherwise
- *
- ****************************************************************************/
-BOOLEAN USBPNP_ValidateDeviceDescriptor
-(
-    PDEVICE_EXTENSION      pDevExt,
-    PUSB_DEVICE_DESCRIPTOR DevDesc
-)
-{
-    if (DevDesc->bLength == 0)
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_ERROR,
-            ("<%s> _ValidateDeviceDescriptor: 0 bLength\n", pDevExt->PortName)
-        );
-        return FALSE;
-    }
-
-    if (DevDesc->bDescriptorType != 0x01)
-    {
-        QCFLT_DbgPrint
-        (
-            DBG_LEVEL_ERROR,
-            ("<%s> _ValidateDeviceDescriptor: bad bDescriptorType 0x%x\n",
-            pDevExt->PortName, DevDesc->bDescriptorType)
-        );
-        return FALSE;
-    }
-    return TRUE;
-}  // USBPNP_ValidateDeviceDescriptor
-
-
-#define MAX_INTERFACE 64
-
-/****************************************************************************
- *
  * function: USBPNP_SelectAndAddInterfaces
  *
  * purpose:  Appends virtual MUX interface descriptors to the USB configuration
@@ -3409,7 +3341,6 @@ NTSTATUS USBPNP_SelectAndAddInterfaces
             pInterfaceDesc->bLength = sizeof(USB_INTERFACE_DESCRIPTOR);
             pInterfaceDesc->bDescriptorType = 0x04;
             pInterfaceDesc->bInterfaceNumber = NUM_START_INTERFACEID + (i * pDevExt->NumMuxRmnetIface) + j; //TODO: check the boundary
-            // InterlockedIncrement(&gMuxDeviceIndex);
             pInterfaceDesc->bAlternateSetting = 0x00;
             pInterfaceDesc->bNumEndpoints = 0x00;
             pInterfaceDesc->iInterface = 0x00;
@@ -3580,7 +3511,6 @@ NTSTATUS QCFilterSetFriendlyName
     PWCHAR          pId;
     DWORD           idLen, restLen, subKeyIdx, subKeyLen;
     int             selected = 0;
-    LONG            regResult;
     HANDLE          hwKeyHandle;
     UNICODE_STRING  ucHwKeyPath;
     OBJECT_ATTRIBUTES oa;

--- a/src/windows/filter/qcfilter.h
+++ b/src/windows/filter/qcfilter.h
@@ -14,10 +14,6 @@ GENERAL DESCRIPTION
 
 *====*====*====*====*====*====*====*====*====*====*====*====*====*====*====*/
 
-#include <ntddk.h>
-#include <wdmsec.h>
-#include <initguid.h>
-
 //
 // GUID definition are required to be outside of header inclusion pragma to avoid
 // error during precompiled headers.
@@ -25,7 +21,6 @@ GENERAL DESCRIPTION
 // {B7D25408-B34A-4f67-BF36-F6182CC0EC48}
 DEFINE_GUID(QMI_DEVICE_INTERFACE_CLASS,
     0xb7d25408, 0xb34a, 0x4f67, 0xbf, 0x36, 0xf6, 0x18, 0x2c, 0xc0, 0xec, 0x48);
-
 
 #if !defined(_FILTER_H_)
 #define _FILTER_H_
@@ -473,14 +468,6 @@ NTSTATUS QCFilterCreateFriendlyName
 (
     PDEVICE_EXTENSION pDevExt,
     PDEVICE_OBJECT QCPhysicalDeviceObject
-);
-
-NTSTATUS QCFilterSetFriendlyName
-(
-    PDEVICE_EXTENSION pDevExt,
-    PDEVICE_OBJECT    QCPhysicalDeviceObject,
-    PUNICODE_STRING   FriendlyName,
-    PWCHAR            TargetDriverKey
 );
 
 #ifdef EVENT_TRACING

--- a/src/windows/filter/qcfilter.h
+++ b/src/windows/filter/qcfilter.h
@@ -30,14 +30,7 @@ DEFINE_GUID(QMI_DEVICE_INTERFACE_CLASS,
 #if !defined(_FILTER_H_)
 #define _FILTER_H_
 
-#ifndef  STATUS_CONTINUE_COMPLETION
-#define STATUS_CONTINUE_COMPLETION      STATUS_SUCCESS
-#endif
-
 #define POOL_TAG   'liFT'
-
-#define NTDEVICE_NAME_STRING        L"\\Device\\QcFilter"
-#define SYMBOLIC_NAME_STRING        L"\\DosDevices\\QcFilter"
 
 #define VEN_DEV_SERNUM              L"QCDeviceSerialNumber"
 #define VEN_DEV_MSM_SERNUM          L"QCDeviceMsmSerialNumber"
@@ -458,12 +451,6 @@ BOOLEAN USBPNP_ValidateConfigDescriptor
 (
     PDEVICE_EXTENSION pDevExt,
     PUSB_CONFIGURATION_DESCRIPTOR ConfigDesc
-);
-
-BOOLEAN USBPNP_ValidateDeviceDescriptor
-(
-    PDEVICE_EXTENSION      pDevExt,
-    PUSB_DEVICE_DESCRIPTOR DevDesc
 );
 
 NTSTATUS USBPNP_SelectAndAddInterfaces

--- a/src/windows/filter/qcfilterioc.c
+++ b/src/windows/filter/qcfilterioc.c
@@ -12,8 +12,8 @@ GENERAL DESCRIPTION
 
 *====*====*====*====*====*====*====*====*====*====*====*====*====*====*====*/
 
-#include "Ntddk.h"
-#include "Usbdi.h"
+#include <ntddk.h>
+#include <usbdi.h>
 
 #include "qcfilter.h"
 #include "qcfilterioc.h"

--- a/src/windows/filter/qcfilterioc.c
+++ b/src/windows/filter/qcfilterioc.c
@@ -14,8 +14,6 @@ GENERAL DESCRIPTION
 
 #include "Ntddk.h"
 #include "Usbdi.h"
-#include "Usbdlib.h"
-#include "Wdm.h"
 
 #include "qcfilter.h"
 #include "qcfilterioc.h"
@@ -46,19 +44,15 @@ ProcessDispatchIrp
 )
 {
     KIRQL levelOrHandle;
-    PIO_STACK_LOCATION irpStack, nextStack;
+    PIO_STACK_LOCATION irpStack;
     PDEVICE_EXTENSION pDevExt;
     PVOID ioBuffer;
     ULONG inputBufferLength, outputBufferLength, ioControlCode;
     NTSTATUS ntStatus = STATUS_SUCCESS, ntCloseStatus = STATUS_SUCCESS, myNts;
-    USHORT usLength;
-    BOOLEAN bRemoveRequest = FALSE;
-    KIRQL irqLevel = KeGetCurrentIrql();
 
     pDevExt = DeviceObject->DeviceExtension;
 
     irpStack = IoGetCurrentIrpStackLocation(Irp);
-    nextStack = IoGetNextIrpStackLocation(Irp);
 
     // get the parameters from an IOCTL call
     ioBuffer = Irp->AssociatedIrp.SystemBuffer;
@@ -135,16 +129,10 @@ ProcessDispatchIrp
                             Irp->IoStatus.Information = sizeof(FILTER_DEVICE_INFO);
                         }
                     }
-                    if (ntStatus == STATUS_SUCCESS)
-                    {
-                        KIRQL levelOrHandle;
-                        PCONTROL_DEVICE_EXTENSION deviceExtension = pFilterDeviceInfo->pControlDeviceObject->DeviceExtension;
-                    }
                 }
                 break;
                 case IOCTL_QCDEV_CLOSE_CTL_FILE:
                 {
-                    KIRQL levelOrHandle;
                     PFILTER_DEVICE_INFO pFilterDeviceInfo;
                     if (inputBufferLength != sizeof(FILTER_DEVICE_INFO))
                     {


### PR DESCRIPTION
### Summary

Simplified friendly-name registration in the qcfilter driver by replacing the outdated registry approach with the `IoSetDevicePropertyData` kernel API. Also removed unreferenced variables, functions, headers from all project files.

### Changes

| File | Change |
|------|--------|
| `qcfilter.c` | Replace `QCFilterSetFriendlyName(...)` call in `QCFilterCreateFriendlyName` with `IoSetDevicePropertyData(PDO, &DEVPKEY_Device_FriendlyName, ...)` |
| `qcfilter.c` | Delete `QCFilterSetFriendlyName` function body (~270 lines) |
| `qcfilter.h` | Remove `QCFilterSetFriendlyName` prototype |

### Behavior

- **No functional change**: `QCFilterCreateFriendlyName` still first checks for an existing `FriendlyName` property; only if absent does it construct and set one.
- The new API writes the same property that Device Manager reads, so the displayed name is identical.
- `IoSetDevicePropertyData` is available on Windows 8 and later (NTDDI_WIN8), which is consistent with the driver's existing use of `ExAllocatePoolZero` and `IoInitializeRemoveLock` with 4-parameter signature.

### Test

Local installation correctly displayed device name with instance id: `Qualcomm USB Composite Device 90DB (0018)`
The device hardware key (`Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\USB\VID_05C6&PID_90DB\`) also contains the correct `friendlyName`:  `Qualcomm USB Composite Device 90DB (0018)`