### PR TITLE
fix(wdfserial): restore TimeoutReadQueue drain for non-RI timeout cases (Case 5/11)

### DIFF
--- a/src/windows/wdfserial/QCRD.c
+++ b/src/windows/wdfserial/QCRD.c
@@ -810,12 +810,33 @@ void QCRD_ReadRequestHandlerThread
                                 }
                                 else
                                 {
-                                    // When bypassing the RI timer due to pre-buffered data, we must NOT
-                                    // drain TimeoutReadQueue: those requests are waiting for the timer to
-                                    // expire (QUD-1837 inter-byte gap semantics). Only serve new requests
-                                    // from ReadQueue during bypass. TimeoutReadQueue requests will be
-                                    // handled by REQUEST_TIMEOUT_EVENT when the timer fires.
-                                    status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
+                                    if (useReadInterval)
+                                    {
+                                        // RI bypass: only serve from ReadQueue to preserve QUD-1837
+                                        // inter-byte gap semantics. TimeoutReadQueue requests are
+                                        // waiting for the RI timer to expire and must not be stolen.
+                                        status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
+                                    }
+                                    else
+                                    {
+                                        // Non-RI cases (Case 5/11, etc.): check TimeoutReadQueue first,
+                                        // then ReadQueue. For these cases the timeout is a simple "wait
+                                        // for data or N ms" — data should be served immediately when it
+                                        // arrives, regardless of which queue holds the request.
+                                        status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &request);
+                                        if (NT_SUCCESS(status) && request != NULL)
+                                        {
+                                            // Found pending request in TimeoutReadQueue — cancel timer
+                                            // since we are serving data now (timeout no longer needed).
+                                            KeCancelTimer(&pDevContext->ReadTimer);
+                                            KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
+                                        }
+                                        else
+                                        {
+                                            // No request in TimeoutReadQueue, try ReadQueue
+                                            status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
+                                        }
+                                    }
                                 }
 
                                 if (!NT_SUCCESS(status) || request == NULL)
@@ -1112,6 +1133,48 @@ void QCRD_ReadRequestHandlerThread
                             );
                         }
                         pDevContext->AmountInInQueue = QCUTIL_RingBufferBytesUsed(rxBuffer);
+                    }
+                }
+                else if (pDevContext->ReadTimeout.bReturnOnAnyChars &&
+                         QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
+                {
+                    // Case 5/11 defensive path: data arrived but was not served by
+                    // REQUEST_ARRIVE_EVENT (should not happen after the drain-loop fix,
+                    // but guard against races). Drain the buffer instead of discarding.
+                    WDFREQUEST timeoutRequest = NULL;
+                    status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &timeoutRequest);
+                    if (NT_SUCCESS(status) && timeoutRequest != NULL)
+                    {
+                        WDF_REQUEST_PARAMETERS toRequestParam;
+                        WDF_REQUEST_PARAMETERS_INIT(&toRequestParam);
+                        WdfRequestGetParameters(timeoutRequest, &toRequestParam);
+
+                        size_t toRequested = toRequestParam.Parameters.Read.Length;
+                        size_t toBytesCopied = 0;
+                        PUCHAR toOutputBuffer = NULL;
+
+                        WdfRequestRetrieveOutputBuffer(timeoutRequest, toRequested, &toOutputBuffer, NULL);
+                        status = QCUTIL_RingBufferRead(rxBuffer, toOutputBuffer, toRequested, &toBytesCopied);
+                        if (NT_SUCCESS(status) && toBytesCopied > 0)
+                        {
+                            WdfRequestCompleteWithInformation(timeoutRequest, STATUS_SUCCESS, toBytesCopied);
+                            QCSER_DbgPrint
+                            (
+                                QCSER_DBG_MASK_READ,
+                                QCSER_DBG_LEVEL_DETAIL,
+                                ("<%ws> RIRP: QCRD_ReadRequestHandlerThread timeout bReturnOnAnyChars drain completed, bytes: %llu\n",
+                                pDevContext->PortName, toBytesCopied)
+                            );
+                        }
+                        else
+                        {
+                            WdfRequestCompleteWithInformation(timeoutRequest, STATUS_TIMEOUT, 0);
+                        }
+                        pDevContext->AmountInInQueue = QCUTIL_RingBufferBytesUsed(rxBuffer);
+                    }
+                    else
+                    {
+                        QCUTIL_IoQueuePopAndComplete(pDevContext->TimeoutReadQueue, STATUS_TIMEOUT, 0);
                     }
                 }
                 else


### PR DESCRIPTION
## Summary

Fixes a regression introduced by PR #65 (`29bc552`) that breaks **COMMTIMEOUTS Case 5** (`ReadIntervalTimeout=MAXDWORD`, `ReadTotalTimeoutMultiplier=MAXDWORD`, `ReadTotalTimeoutConstant=N`). This configuration is used by **EMMCDL** and other Sahara/EDL protocol tools for bounded blocking reads on Qualcomm serial ports.

## Problem

After PR #65, `ReadFile()` returns with **0 bytes** and `STATUS_TIMEOUT` regardless of whether data has arrived within the timeout period. The device's Sahara HELLO_REQ packet is received by the driver and buffered in the ring buffer, but it is never delivered to the application. This causes the EDL flashing handshake to fail.

## Root Cause

PR #65 changed the drain loop in the `REQUEST_ARRIVE_EVENT` handler to **only retrieve requests from `ReadQueue`**:

```c
// PR #65 code (line 818):
status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
```

For Case 5, when the ring buffer is initially empty, the read request is moved to `TimeoutReadQueue` and a timer is armed for N ms. When data subsequently arrives:

1. The drain loop tries `ReadQueue` → **empty** (request is in `TimeoutReadQueue`)
2. `request = NULL` → loop breaks → data remains stranded in ring buffer
3. Timer fires → `REQUEST_TIMEOUT_EVENT` handler checks `bUseReadInterval` (FALSE for Case 5) → completes with `STATUS_TIMEOUT, 0 bytes`

The pre-PR#65 code (from QUD-1837) correctly checked `TimeoutReadQueue` **first**, cancelled the timer, and served data immediately.

### Failure timeline

```
T=0ms     ReadFile() called → request enters ReadQueue
          ARRIVE_EVENT: buffer empty → move request to TimeoutReadQueue, arm timer (N ms)

T=Xms     Device sends HELLO_REQ → data enters ring buffer
          ARRIVE_EVENT: buffer has data → drain loop
            WdfIoQueueRetrieveNextRequest(ReadQueue) → EMPTY! (request is in TimeoutReadQueue)
            → break (data stranded in ring buffer)

T=Nms     Timer fires → TIMEOUT_EVENT
            bUseReadInterval = FALSE → QCUTIL_IoQueuePopAndComplete(TimeoutReadQueue, STATUS_TIMEOUT, 0)
            → ReadFile returns 0 bytes. HELLO_REQ data LOST in ring buffer.
```

## Why PR #65 Made This Change

PR #65 was designed to fix a latency regression for **ReadInterval (RI) cases** (Cases 9/10). For RI cases, requests in `TimeoutReadQueue` must NOT be served by the drain loop because they are waiting for the inter-byte gap timer to expire (QUD-1837 semantics). However, the `ReadQueue`-only restriction was applied **unconditionally** to all timeout cases, breaking Case 5/11 where the timeout is a simple "wait for data or N ms" mechanism.

## Fix

### Change 1: Conditional queue selection in drain loop

The drain loop now selects the queue source based on `useReadInterval`:

- **`useReadInterval = TRUE`** (Cases 9/10): Only read from `ReadQueue` — preserves QUD-1837 inter-byte gap semantics
- **`useReadInterval = FALSE`** (Cases 5/11): Check `TimeoutReadQueue` first, cancel timer if found, then fall back to `ReadQueue` — restores immediate data delivery

```c
if (useReadInterval)
{
    // RI bypass: only serve from ReadQueue (QUD-1837 semantics)
    status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
}
else
{
    // Non-RI: check TimeoutReadQueue first, then ReadQueue
    status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &request);
    if (NT_SUCCESS(status) && request != NULL)
    {
        KeCancelTimer(&pDevContext->ReadTimer);
        KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
    }
    else
    {
        status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
    }
}
```

### Change 2: Defensive timeout handler for `bReturnOnAnyChars`

Added a `bReturnOnAnyChars` check in `REQUEST_TIMEOUT_EVENT` that drains the ring buffer if data is present. This prevents data loss from any residual timing races (defensive, should not normally fire after Change 1).

## Affected COMMTIMEOUTS Configuration

```c
// Case 5 (EMMCDL, Sahara protocol tools):
ReadIntervalTimeout        = MAXDWORD (0xFFFFFFFF)
ReadTotalTimeoutMultiplier = MAXDWORD (0xFFFFFFFF)
ReadTotalTimeoutConstant   = N ms (e.g., 5000)
```

Per [Microsoft docs](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts): return immediately if bytes available, otherwise wait up to N ms.

## Testing

- Case 5 (EMMCDL): ReadFile correctly blocks until data arrives, then returns with data immediately
- Cases 9/10 (ReadInterval): QUD-1837 inter-byte gap semantics preserved — no regression
- Case 3 (simple total timeout): Unaffected (request stays in ReadQueue)

## Related

- **Fixes regression from:** PR #65 (`29bc552`)
- **Original QUD-1837 implementation:** `9e60a01`
- **Reported issue:** EMMCDL EDL flashing failure with QUD v1.00.94.9