### PR TITLE
fix: NULL pointer dereference BSOD during concurrent 5G module reset [Case#08589733]

### DIFF
--- a/src/windows/transport/usb/USBMRD.c
+++ b/src/windows/transport/usb/USBMRD.c
@@ -634,13 +634,30 @@ NTSTATUS MultiReadCompletionRoutine
 )
 {
     PUSBMRD_L2BUFFER  pL2Ctx = (PUSBMRD_L2BUFFER)Context;
-    PDEVICE_EXTENSION pDevExt = pL2Ctx->DeviceExtension;
-    KIRQL             Irql = KeGetCurrentIrql();
+    PDEVICE_EXTENSION pDevExt;
+    KIRQL             Irql;
 #ifdef QCUSB_TARGET_XP
     KLOCK_QUEUE_HANDLE levelOrHandle;
 #else
     KIRQL levelOrHandle;
 #endif
+
+    // Guard against NULL context during concurrent device removal.
+    // When multiple devices are surprise-removed simultaneously, the
+    // completion routine may fire after the device extension has been
+    // torn down, leading to a NULL pointer dereference at DISPATCH_LEVEL.
+    if (pL2Ctx == NULL)
+    {
+        return STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
+    pDevExt = pL2Ctx->DeviceExtension;
+    if (pDevExt == NULL)
+    {
+        return STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
+    Irql = KeGetCurrentIrql();
 
     QcAcquireSpinLockWithLevel(&pDevExt->L2Lock, &levelOrHandle, Irql);
 

--- a/src/windows/transport/usb/USBRD.c
+++ b/src/windows/transport/usb/USBRD.c
@@ -468,6 +468,15 @@ NTSTATUS ReadCompletionRoutine
 {
     PDEVICE_EXTENSION pDevExt = (PDEVICE_EXTENSION)pContext;
 
+    // Guard against NULL context during concurrent device removal.
+    // When multiple devices are surprise-removed simultaneously, the
+    // completion routine may fire after the device extension has been
+    // torn down, leading to a NULL pointer dereference at DISPATCH_LEVEL.
+    if (pDevExt == NULL)
+    {
+        return STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
 #ifdef QCOM_TRACE_IN
     DbgPrint("L2 OFF\n");
 #endif


### PR DESCRIPTION
## Summary

Fix NULL pointer dereference in USB read completion routines that causes BSOD when multiple 5G modules (SA522M/RN934V) reboot or reset simultaneously.

## Problem

Connected 5 SA522M/RN934V modules to a test computer running Windows 11 24H2 (Build 26100). When the modules reboot/reset at nearly the same time, the system intermittently hits a Blue Screen of Death.

**Observed bug checks (10 crashes across 2 machines CFG14/CFG18):**
- **DRIVER_IRQL_NOT_LESS_OR_EQUAL (0xD1)** in qcusbwwan.sys at +0x2B465 - 7 occurrences
- **SYSTEM_THREAD_EXCEPTION_NOT_HANDLED (0x7E)** in qcusbser.sys at +0x892B - 3 occurrences

## Root Cause

Race condition between USB IRP completion callbacks and PnP device teardown during concurrent device removal:

1. When 5 modules reboot simultaneously, Windows processes surprise removals for all devices in parallel across multiple processors (12-core system)
2. The PnP removal path frees/NULLs the device extension context
3. Pending USB read IRP completions fire at DISPATCH_LEVEL with a stale/NULL context pointer
4. `ReadCompletionRoutine` in USBRD.c and `MultiReadCompletionRoutine` in USBMRD.c dereference the NULL pointer without any validation, causing the crash

**Crash signature (consistent across all 7 qcusbwwan dumps):**
- Memory address accessed: `0x0000000000000040` (NULL + offset 0x40 = struct field access on NULL pointer)
- IRQL: 2 (DISPATCH_LEVEL)
- Access type: Read
- Faulting instruction: `qcusbwwan.sys + 0x2B465`

## Fix

Add NULL pointer guards to both completion routines:

**USBRD.c - `ReadCompletionRoutine` (line 462):**
- Added NULL check on `pContext` (pDevExt) before accessing `pDevExt->pL2ReadEvents[]`
- Returns `STATUS_MORE_PROCESSING_REQUIRED` immediately if NULL (safe no-op for the IRP framework)

**USBMRD.c - `MultiReadCompletionRoutine` (line 629):**
- Added NULL check on `Context` (pL2Ctx) before dereferencing
- Added NULL check on `pL2Ctx->DeviceExtension` (pDevExt) before accessing device state
- Moved variable declarations to comply with C89/kernel-mode requirements
- Returns `STATUS_MORE_PROCESSING_REQUIRED` immediately if either is NULL

## Safety Analysis

- **Zero impact on normal operation**: The NULL check is never taken during normal device functioning (one branch instruction cost)
- **Correct return value**: `STATUS_MORE_PROCESSING_REQUIRED` is the only valid return for these completion routines regardless
- **No structural changes**: No new locks, allocations, or logic changes to the existing code path
- **Teardown-safe**: When the NULL guard triggers, the device is already being torn down - the L2 read thread is being cancelled via CancelReadEvent and will terminate regardless of the missed event signal

## Testing Recommendations

- Reproduce with 5 modules under concurrent reset stress test
- Enable Driver Verifier (Special Pool + Deadlock Detection) on qcusbwwan.sys
- Validate fix under rapid plug/unplug cycling
- Verify no regression in normal single-device operation

## Environment

- Windows 11 24H2 (Build 26100), AMD64, 12 processors
- Driver versions: qcusbwwan.sys 4.0.9.2, qcusbser.sys 2.1.9.0
- Hardware: 5x RN934V/SA522M modules
- Test machines: CFG14 (5 crashes), CFG18 (5 crashes)

## References

- Case#08589733