### PR TITLE
fix(wdfserial): restore TimeoutReadQueue drain for non-RI timeout cases (Case 5/11)

### DIFF
--- a/src/windows/wdfserial/QCRD.c
+++ b/src/windows/wdfserial/QCRD.c
@@ -810,12 +810,33 @@ void QCRD_ReadRequestHandlerThread
                                 }
                                 else
                                 {
-                                    // When bypassing the RI timer due to pre-buffered data, we must NOT
-                                    // drain TimeoutReadQueue: those requests are waiting for the timer to
-                                    // expire (QUD-1837 inter-byte gap semantics). Only serve new requests
-                                    // from ReadQueue during bypass. TimeoutReadQueue requests will be
-                                    // handled by REQUEST_TIMEOUT_EVENT when the timer fires.
-                                    status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
+                                    if (useReadInterval)
+                                    {
+                                        // RI bypass: only serve from ReadQueue to preserve QUD-1837
+                                        // inter-byte gap semantics. TimeoutReadQueue requests are
+                                        // waiting for the RI timer to expire and must not be stolen.
+                                        status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
+                                    }
+                                    else
+                                    {
+                                        // Non-RI cases (Case 5/11, etc.): check TimeoutReadQueue first,
+                                        // then ReadQueue. For these cases the timeout is a simple "wait
+                                        // for data or N ms" — data should be served immediately when it
+                                        // arrives, regardless of which queue holds the request.
+                                        status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &request);
+                                        if (NT_SUCCESS(status) && request != NULL)
+                                        {
+                                            // Found pending request in TimeoutReadQueue — cancel timer
+                                            // since we are serving data now (timeout no longer needed).
+                                            KeCancelTimer(&pDevContext->ReadTimer);
+                                            KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
+                                        }
+                                        else
+                                        {
+                                            // No request in TimeoutReadQueue, try ReadQueue
+                                            status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
+                                        }
+                                    }
                                 }
 
                                 if (!NT_SUCCESS(status) || request == NULL)
@@ -1112,6 +1133,48 @@ void QCRD_ReadRequestHandlerThread
                             );
                         }
                         pDevContext->AmountInInQueue = QCUTIL_RingBufferBytesUsed(rxBuffer);
+                    }
+                }
+                else if (pDevContext->ReadTimeout.bReturnOnAnyChars &&
+                         QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
+                {
+                    // Case 5/11 defensive path: data arrived but was not served by
+                    // REQUEST_ARRIVE_EVENT (should not happen after the drain-loop fix,
+                    // but guard against races). Drain the buffer instead of discarding.
+                    WDFREQUEST timeoutRequest = NULL;
+                    status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &timeoutRequest);
+                    if (NT_SUCCESS(status) && timeoutRequest != NULL)
+                    {
+                        WDF_REQUEST_PARAMETERS toRequestParam;
+                        WDF_REQUEST_PARAMETERS_INIT(&toRequestParam);
+                        WdfRequestGetParameters(timeoutRequest, &toRequestParam);
+
+                        size_t toRequested = toRequestParam.Parameters.Read.Length;
+                        size_t toBytesCopied = 0;
+                        PUCHAR toOutputBuffer = NULL;
+
+                        WdfRequestRetrieveOutputBuffer(timeoutRequest, toRequested, &toOutputBuffer, NULL);
+                        status = QCUTIL_RingBufferRead(rxBuffer, toOutputBuffer, toRequested, &toBytesCopied);
+                        if (NT_SUCCESS(status) && toBytesCopied > 0)
+                        {
+                            WdfRequestCompleteWithInformation(timeoutRequest, STATUS_SUCCESS, toBytesCopied);
+                            QCSER_DbgPrint
+                            (
+                                QCSER_DBG_MASK_READ,
+                                QCSER_DBG_LEVEL_DETAIL,
+                                ("<%ws> RIRP: QCRD_ReadRequestHandlerThread timeout bReturnOnAnyChars drain completed, bytes: %llu\n",
+                                pDevContext->PortName, toBytesCopied)
+                            );
+                        }
+                        else
+                        {
+                            WdfRequestCompleteWithInformation(timeoutRequest, STATUS_TIMEOUT, 0);
+                        }
+                        pDevContext->AmountInInQueue = QCUTIL_RingBufferBytesUsed(rxBuffer);
+                    }
+                    else
+                    {
+                        QCUTIL_IoQueuePopAndComplete(pDevContext->TimeoutReadQueue, STATUS_TIMEOUT, 0);
                     }
                 }
                 else


### PR DESCRIPTION
# Deep Analysis: PR #65 ReadFile Regression for EMMCDL (Case 5 COMMTIMEOUTS)

**Date:** 2026-07-13  
**Driver:** qcwdfserial.sys (WDF Serial Driver)  
**PR Under Analysis:** https://github.com/qualcomm/qcom-usb-kernel-drivers/pull/65  
**Symptom:** ReadFile() returns with 0 bytes; device's Sahara HELLO_REQ data is lost  
**Affected COMMTIMEOUTS configuration:** MAXDWORD / MAXDWORD / N (Case 5)

---

## Executive Summary

PR #65 introduced a regression for **COMMTIMEOUTS Case 5** (`ReadIntervalTimeout=MAXDWORD`, `ReadTotalTimeoutMultiplier=MAXDWORD`, `ReadTotalTimeoutConstant=N`). The drain loop in the `REQUEST_ARRIVE_EVENT` handler was changed to retrieve requests **only from `ReadQueue`**, but for Case 5, the request has already been moved to `TimeoutReadQueue`. When data arrives, the drain loop cannot locate the request, leaving data stranded in the ring buffer. The timeout timer then fires and completes the request via `QCUTIL_IoQueuePopAndComplete(TimeoutReadQueue, STATUS_TIMEOUT, 0)` — returning **0 bytes regardless of ring buffer content**.

---

## 1. EMMCDL's COMMTIMEOUTS Configuration (Case 5)

```c
ReadIntervalTimeout        = MAXDWORD (0xFFFFFFFF)
ReadTotalTimeoutMultiplier = MAXDWORD (0xFFFFFFFF)
ReadTotalTimeoutConstant   = N ms (e.g., 10 / 1000 / 5000)
```

Per [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts), this specific combination means:
> "If there are any bytes in the input buffer, ReadFile returns immediately with the bytes in the buffer. If there are no bytes in the input buffer, the operation waits until a byte arrives and then returns immediately. The total timeout is ReadTotalTimeoutConstant."

The QUD driver classifies this as **`QCSER_READ_TIMEOUT_CASE_5`** with:
- `bUseReadInterval = FALSE` (because `ReadIntervalTimeout == MAXULONG`)
- `bReturnOnAnyChars = TRUE`
- Timer period = `ReadTotalTimeoutConstant` (N ms)

---

## 2. Key Variable: `useReadInterval`

```c
// QCRD.c, line ~619 (after PR #65)
BOOLEAN useReadInterval = (pDevContext->ReadTimeout.bUseReadInterval &&
                           pDevContext->Timeouts.ReadIntervalTimeout > 0 &&
                           pDevContext->Timeouts.ReadIntervalTimeout != MAXULONG);
```

For EMMCDL's Case 5:
- `bUseReadInterval = FALSE` (set during IOCTL_SERIAL_SET_TIMEOUTS processing)
- `ReadIntervalTimeout = MAXULONG`
- **Result: `useReadInterval = FALSE`**

This is critical because PR #65's Guard and timer-cancel logic are both gated on `useReadInterval == TRUE`.

---

## 3. Root Cause: Drain Loop Only Checks `ReadQueue`

### The Problematic Code (PR #65, line 818)

```c
else  // data available in ring buffer
{
    // Guard: useReadInterval && TimeoutReadQueue not empty && ReadQueue empty → skip
    if (useReadInterval &&                                    // FALSE for Case 5
        !QCUTIL_IsIoQueueEmpty(pDevContext->TimeoutReadQueue) &&
        QCUTIL_IsIoQueueEmpty(pDevContext->ReadQueue))
    {
        // keep timer-based completion (Cases 9/10 only)
    }
    else
    {
        if (useReadInterval)  // FALSE for Case 5 → timer NOT cancelled
        {
            KeCancelTimer(&pDevContext->ReadTimer);
            KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
        }

        while (QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
        {
            // *** THE BUG: Only retrieves from ReadQueue ***
            status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
            //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            //     For Case 5, the request is in TimeoutReadQueue!
            //     ReadQueue is EMPTY → request = NULL → break immediately

            if (!NT_SUCCESS(status) || request == NULL)
            {
                break;  // ← exits drain loop without serving data
            }
            // ... (drain logic never reached for Case 5)
        }
    }
}
```

### The Pre-PR#65 Code (QUD-1837 original, before PR #53 Guard broke it)

```c
// Original working code checked TimeoutReadQueue FIRST:
status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &pendingTimeoutRequest);
if (pendingTimeoutRequest != NULL)
{
    KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
    KeCancelTimer(&pDevContext->ReadTimer);
    request = pendingTimeoutRequest;
    pendingTimeoutRequest = NULL;
}
else
{
    status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
}
```

This correctly served Case 5 requests by checking `TimeoutReadQueue` first, cancelling the timer, and draining the ring buffer immediately when data arrived.

---

## 4. Complete Failure Trace for Case 5 with PR #65

```
Timeline:
=========

T=0ms     EMMCDL calls ReadFile(hCom, buf, N, ...)
          → IRP enters ReadQueue
          → ReadRequestArriveEvent signaled

T=0ms     READ_THREAD_REQUEST_ARRIVE_EVENT fires
          Ring buffer: EMPTY
          useReadInterval = FALSE → skip RI path
          → enters "else if (buffer == 0)" branch (line 691)
          → WdfIoQueueRetrieveNextRequest(ReadQueue) → gets request
          → QCRD_StartReadTimeout(Case 5, N ms) → returns TRUE
          → WdfRequestForwardToIoQueue(request, TimeoutReadQueue)
          → Timer armed for N ms
          
          State: request in TimeoutReadQueue, timer running, ReadQueue empty

T=Xms     Device sends HELLO_REQ (X < N)
          → USB bulk-in completion
          → Data written to ring buffer
          → ReadRequestArriveEvent signaled

T=Xms     READ_THREAD_REQUEST_ARRIVE_EVENT fires
          Ring buffer: HAS DATA (HELLO_REQ bytes)
          useReadInterval = FALSE
          → enters "else" branch (data available, line 753)
          
          Guard check: useReadInterval(FALSE) && ... → FALSE → skip guard
          Timer cancel: if(useReadInterval) → FALSE → TIMER NOT CANCELLED
          
          Drain loop:
            WdfIoQueueRetrieveNextRequest(ReadQueue, &request)
            → ReadQueue is EMPTY (request is in TimeoutReadQueue!)
            → request = NULL
            → break
          
          State: data STRANDED in ring buffer, request still in TimeoutReadQueue
                 timer still running (N - X ms remaining)

T=Nms     Timer fires → ReadTimeoutDpc → signals ReadRequestTimeoutEvent

T=Nms     READ_THREAD_REQUEST_TIMEOUT_EVENT fires (line 1060)
          KeClearEvent(&ReadRequestTimeoutEvent)
          KeCancelTimer(&ReadTimer)
          
          Check: bUseReadInterval(FALSE) && buffer > 0 → FALSE
                 (bUseReadInterval is FALSE for Case 5!)
          
          → enters "else" branch (line 1117-1119):
            QCUTIL_IoQueuePopAndComplete(TimeoutReadQueue, STATUS_TIMEOUT, 0)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            Completes request with STATUS_TIMEOUT and ***0 BYTES***
          
          State: ReadFile returns 0 bytes. HELLO_REQ data REMAINS in ring buffer.
          
RESULT:   ReadFile() returns after N ms with 0 bytes read.
          Sahara HELLO_REQ data is lost (stranded in ring buffer).
          EMMCDL handshake fails.
```

---

## 5. Why the Timeout Handler Returns 0 Bytes for Case 5

The `REQUEST_TIMEOUT_EVENT` handler (line 1060-1121) has this structure:

```c
case READ_THREAD_REQUEST_TIMEOUT_EVENT:
{
    KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
    KeCancelTimer(&pDevContext->ReadTimer);

    // QUD-1837: Only drain ring buffer for ReadIntervalTimeout cases
    if (pDevContext->ReadTimeout.bUseReadInterval &&      // FALSE for Case 5!
        QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
    {
        // ... drain buffer, complete with data (Cases 9/10 only)
    }
    else
    {
        // Case 5 lands here: simple timeout completion with 0 bytes
        QCUTIL_IoQueuePopAndComplete(pDevContext->TimeoutReadQueue, STATUS_TIMEOUT, 0);
    }
    break;
}
```

For Case 5, `bUseReadInterval = FALSE`, so the QUD-1837 partial-read path is skipped. The handler unconditionally completes with `STATUS_TIMEOUT, 0` — **even when the ring buffer contains data**.

This was CORRECT in the original QUD-1837 design because the `REQUEST_ARRIVE_EVENT` handler was supposed to serve data immediately (checking TimeoutReadQueue first). The timeout was only a fallback for "no data arrived within N ms."

PR #65 broke this contract by preventing the ARRIVE_EVENT handler from finding the request in TimeoutReadQueue.

---

## 6. The "Immediate Return" Observation

The customer reports the read returns "in approximately ms" rather than waiting the full timeout. Two explanations:

### Explanation A: Binary predates PR #65 (previous analysis)
The earlier forensic analysis showed the shipped binary (ProductVersion 1.00.94.8) was built from commit `493e06f` before PR #65 was merged. That binary has the PR #53 Guard bug which produces the same symptom (0 bytes, data lost) but via a different code path (the unconditional Guard `break`).

### Explanation B: With PR #65 included
If the tested binary genuinely includes PR #65, the read returns after N ms (not immediately) with 0 bytes. The customer's "approximately ms" phrasing may refer to a very short elapsed time compared to expected behavior, or their QueryPerformanceCounter instrumentation may be measuring the wrong interval.

### Key Point
Regardless of which binary is tested, the **observable symptom is identical**: ReadFile returns 0 bytes, HELLO_REQ data is lost. The difference is timing — PR #53 bug causes 0-byte return after N ms (via timer → STATUS_TIMEOUT path), and PR #65 causes the same (data stranded → timer fires → 0 bytes).

---

## 7. PR #65's Design Intent vs. Actual Impact

PR #65 was designed to fix a **latency regression for ReadInterval (RI) cases** (Cases 9/10) where small-chunk reads experienced unnecessary delay. Its changes:

| Change | Intent | Impact on RI Cases (9/10) | Impact on Case 5 (EMMCDL) |
|--------|--------|---------------------------|---------------------------|
| Gate RI path on `buffer == 0` | Don't enter RI timer path if data already buffered | ✓ Correct | No effect (`useReadInterval=FALSE`) |
| Guard gated on `useReadInterval` | Only preserve QUD-1837 RI semantics for RI cases | ✓ Correct | ✓ Correct (guard skipped) |
| Drain loop only reads `ReadQueue` | Don't steal RI-pending requests from TimeoutReadQueue | ✓ Correct for RI | **✗ BREAKS Case 5** |
| Timer cancel gated on `useReadInterval` | Only cancel RI timer during bypass | ✓ Correct | **✗ Timer not cancelled for Case 5** |

The comment at line 813-817 explains the intent:
> "When bypassing the RI timer due to pre-buffered data, we must NOT drain TimeoutReadQueue: those requests are waiting for the timer to expire (QUD-1837 inter-byte gap semantics)."

This is correct for RI cases. But it incorrectly applies the same logic to **all** cases, including Case 5 where the timeout is a simple "wait for data or N ms" — not an inter-byte gap timer.

---

## 8. Solution

The fix must make the drain loop's queue selection conditional on `useReadInterval`:

```c
// iterate through the ring buffer
while (QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
{
    if (pDevContext->DeviceFunction == QCUSB_DEV_FUNC_VI)
    {
        // ... VI path unchanged ...
    }
    else
    {
        if (useReadInterval)
        {
            // RI bypass: only serve from ReadQueue to preserve
            // QUD-1837 inter-byte gap semantics for TimeoutReadQueue requests
            status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
        }
        else
        {
            // Non-RI cases (Case 5, 11, etc.): check TimeoutReadQueue first,
            // then ReadQueue. This restores the pre-regression behavior where
            // data is served immediately regardless of which queue holds the request.
            status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &request);
            if (NT_SUCCESS(status) && request != NULL)
            {
                // Found request in TimeoutReadQueue — cancel timer since we're
                // serving data now (timeout is no longer needed)
                KeCancelTimer(&pDevContext->ReadTimer);
                KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
            }
            else
            {
                // No request in TimeoutReadQueue, try ReadQueue
                status = WdfIoQueueRetrieveNextRequest(pDevContext->ReadQueue, &request);
            }
        }
    }

    if (!NT_SUCCESS(status) || request == NULL)
    {
        break;
    }
    // ... rest of drain logic unchanged ...
}
```

### Additionally, the `REQUEST_TIMEOUT_EVENT` handler should also drain the buffer for `bReturnOnAnyChars` cases:

```c
case READ_THREAD_REQUEST_TIMEOUT_EVENT:
{
    KeClearEvent(&pDevContext->ReadRequestTimeoutEvent);
    KeCancelTimer(&pDevContext->ReadTimer);

    if (pDevContext->ReadTimeout.bUseReadInterval &&
        QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
    {
        // QUD-1837: RI partial read delivery (existing code)
        // ...
    }
    else if (pDevContext->ReadTimeout.bReturnOnAnyChars &&
             QCUTIL_RingBufferBytesUsed(rxBuffer) > 0)
    {
        // Case 5/11: Data arrived but wasn't served by ARRIVE_EVENT
        // (defensive: drain buffer instead of discarding data)
        WDFREQUEST timeoutRequest = NULL;
        status = WdfIoQueueRetrieveNextRequest(pDevContext->TimeoutReadQueue, &timeoutRequest);
        if (NT_SUCCESS(status) && timeoutRequest != NULL)
        {
            WDF_REQUEST_PARAMETERS timeoutParam;
            WDF_REQUEST_PARAMETERS_INIT(&timeoutParam);
            WdfRequestGetParameters(timeoutRequest, &timeoutParam);
            size_t requested = timeoutParam.Parameters.Read.Length;
            size_t copied = 0;
            PUCHAR outputBuf = NULL;
            WdfRequestRetrieveOutputBuffer(timeoutRequest, requested, &outputBuf, NULL);
            QCUTIL_RingBufferRead(rxBuffer, outputBuf, requested, &copied);
            WdfRequestCompleteWithInformation(timeoutRequest,
                (copied > 0 ? STATUS_SUCCESS : STATUS_TIMEOUT), copied);
        }
    }
    else
    {
        QCUTIL_IoQueuePopAndComplete(pDevContext->TimeoutReadQueue, STATUS_TIMEOUT, 0);
    }
    break;
}
```

---

## 9. Answers to the Customer's Questions

### Q1: Was there an intentional change in how ReadFile() interprets MAXDWORD+MAXDWORD+N?

**No.** PR #65 did not intentionally change Case 5 behavior. The change to only retrieve from `ReadQueue` in the drain loop was intended exclusively for ReadInterval (RI) cases (Cases 9/10). Case 5 was collateral damage because the drain logic applies unconditionally to all non-VI device types.

### Q2: Is the v1.00.94.9 behavior (0 bytes, ignoring timeout) intentional or a regression?

**This is a regression.** The correct behavior for Case 5 is:
- Block until data arrives (return immediately with data), OR
- Block for up to ReadTotalTimeoutConstant ms if no data arrives (return 0 bytes on timeout)

### Q3: Recommended COMMTIMEOUTS for bounded blocking read?

**Immediate workaround** (no driver change required):
```c
// Use Case 3 instead of Case 5:
ReadIntervalTimeout        = 0;
ReadTotalTimeoutMultiplier = 0;
ReadTotalTimeoutConstant   = N;  // e.g., 5000 ms
```

Case 3 avoids the `TimeoutReadQueue` path entirely. The request stays in `ReadQueue` and is served directly by the drain loop when data arrives.

**Long-term:** Apply the fix described in Section 8 so that Case 5 works correctly.

---

## 10. Version Impact Summary

| Version | Contains PR #53 Guard Bug | Contains PR #65 Drain Bug | Case 5 Behavior |
|---------|--------------------------|--------------------------|-----------------|
| v1.00.94.5 (working) | No | No | ✓ Correct |
| v1.00.94.9 binary (built before PR#65) | **Yes** | No | ✗ 0 bytes (Guard break) |
| Main branch (with PR#65) | Fixed by PR#65 | **Yes** | ✗ 0 bytes (drain can't find request) |
| **After proposed fix** | Fixed | Fixed | ✓ Correct |

---

## 11. Summary

PR #65 fixed the PR #53 Guard bug for ReadInterval cases but simultaneously introduced a **new regression for Case 5** by making the drain loop only check `ReadQueue`. For Case 5 (EMMCDL's timeout configuration), the read request resides in `TimeoutReadQueue` and is unreachable by the drain loop. Data arrives and is buffered, but the request is never served until the timer fires, at which point the timeout handler completes with 0 bytes (because the `bUseReadInterval` check gates the buffer-drain path in the timeout handler).

The fix is to make the drain loop conditionally check `TimeoutReadQueue` first when `useReadInterval` is FALSE, restoring the original behavior where Case 5 requests are served immediately upon data arrival.