### PR TITLE
fix: NULL pointer dereference BSOD during concurrent 5G module reset [Case#08589733]

### DIFF
--- a/src/windows/transport/usb/USBMRD.c
+++ b/src/windows/transport/usb/USBMRD.c
@@ -826,6 +826,25 @@ void USBMRD_L2MultiReadThread(PDEVICE_EXTENSION pDevExt)
                     NULL
                 )
 
+                // Acquire RemoveLock before calling IoCallDriver so that pDevExt
+                // cannot be freed by IoReleaseRemoveLockAndWait for the entire
+                // duration of this L2 IRP. A failed return value indicates that
+                // the device is in the process of being removed; therefore, the
+                // L2 thread should terminate.
+                ntStatus = IoAcquireRemoveLock(pDevExt->pRemoveLock, pIrp);
+                if (!NT_SUCCESS(ntStatus))
+                {
+                    QCUSB_DbgPrint
+                    (
+                        QCUSB_DBG_MASK_READ,
+                        QCUSB_DBG_LEVEL_CRITICAL,
+                        ("<%s> ML2: AcquireRemoveLock failed 0x%x, device removing\n",
+                        pDevExt->PortName, ntStatus)
+                    );
+                    pDevExt->bL2Stopped = TRUE;
+                    break;
+                }
+
                     pDevExt->pL2ReadBuffer[pDevExt->L2IrpEndIdx].State = L2BUF_STATE_PENDING;
 
                 //PendingQueue
@@ -1373,6 +1392,7 @@ wait_for_completion:
                                     IO_NO_INCREMENT,
                                     FALSE
                                 );
+                                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                                 goto wait_for_completion;
                             }
                             if (inDevState(DEVICE_STATE_PRESENT_AND_STARTED))
@@ -1400,6 +1420,7 @@ wait_for_completion:
                     if (pActiveL2Buf != NULL)
                     {
                         IoCancelIrp(pActiveL2Buf->Irp);
+                        IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                         goto wait_for_completion;
                     }
                     else
@@ -1438,6 +1459,7 @@ wait_for_completion:
                     pDevExt->bL2Stopped = TRUE;
                 }
 
+                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                 break;
             }  // default
 
@@ -1467,11 +1489,16 @@ wait_for_completion:
         pDevExt->hRxLogFile = NULL;
     }
 
-    // Empty the L2 completion queue
+    // Drain the L2 completion queue and release any RemoveLocks that were
+    // acquired when each IRP was submitted but whose completions were never
+    // processed by the main loop.
     QcAcquireSpinLock(&pDevExt->L2Lock, &levelOrHandle);
     while (!IsListEmpty(&pDevExt->L2CompletionQueue))
     {
+        PUSBMRD_L2BUFFER pBuf;
         headOfList = RemoveHeadList(&pDevExt->L2CompletionQueue);
+        pBuf = CONTAINING_RECORD(headOfList, USBMRD_L2BUFFER, List);
+        IoReleaseRemoveLock(pDevExt->pRemoveLock, pBuf->Irp);
     }
     QcReleaseSpinLock(&pDevExt->L2Lock, levelOrHandle);
 

--- a/src/windows/transport/usb/USBRD.c
+++ b/src/windows/transport/usb/USBRD.c
@@ -1167,6 +1167,25 @@ void QCUSB_ReadThread(PDEVICE_EXTENSION pDevExt)
                     NULL
                 )
                     QCPWR_CancelIdleTimer(pDevExt, QCUSB_BUSY_WT, TRUE, 20);  // RX in progress, set busy and cancel idle IRP
+
+                // Acquire RemoveLock before calling IoCallDriver so that pDevExt
+                // cannot be freed by IoReleaseRemoveLockAndWait for the entire
+                // duration of this L2 IRP. A failed return value indicates that
+                // the device is in the process of being removed; therefore, the
+                // L2 thread should terminate.
+                ntStatus = IoAcquireRemoveLock(pDevExt->pRemoveLock, pIrp);
+                if (!NT_SUCCESS(ntStatus))
+                {
+                    QCUSB_DbgPrint
+                    (
+                        QCUSB_DBG_MASK_READ,
+                        QCUSB_DBG_LEVEL_CRITICAL,
+                        ("<%s> L2: AcquireRemoveLock failed 0x%x, device is being removed\n",
+                        pDevExt->PortName, ntStatus)
+                    );
+                    pDevExt->bL2Stopped = TRUE;
+                    goto wait_for_completion;
+                }
                 pDevExt->bL2ReadActive = TRUE;
                 ntStatus = IoCallDriver(pDevExt->StackDeviceObject, pIrp);
                 if (ntStatus != STATUS_PENDING)
@@ -1373,6 +1392,7 @@ wait_for_completion:
                                     IO_NO_INCREMENT,
                                     FALSE
                                 );
+                                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                                 goto wait_for_completion;
                             }
                         }
@@ -1386,6 +1406,7 @@ wait_for_completion:
                         FALSE
                     );
 
+                    IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                     continue;
                 }
 
@@ -1402,6 +1423,7 @@ wait_for_completion:
                     pDevExt->bL2Stopped = TRUE;
                 }
 
+                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                 break;
             }
 


### PR DESCRIPTION
### Problem

- Please refer to https://github.com/qualcomm/qcom-usb-kernel-drivers/pull/71 for full details about this issue.

On device removal, `IoReleaseRemoveLockAndWait` is supposed to drain all
outstanding `IoAcquireRemoveLock` calls before freeing `pDevExt`.  However,
the L2 USB read threads (`USBMRD_L2MultiReadThread` and `QCUSB_ReadThread`)
submitted IRPs to the USB stack via `IoCallDriver` **without** holding the
RemoveLock across the IRP lifetime.  This created a window where:

1. Device removal calls `IoReleaseRemoveLockAndWait`, which sees a zero
   outstanding count and proceeds to free `pDevExt`.
2. The USB completion handler (or the L2 thread processing the completion)
   is still running and dereferences the now-freed `pDevExt`.

Result: **use-after-free BSOD** on device hot-unplug or surprise removal.

A secondary issue existed in `USBMRD_L2MultiReadThread`: when the
`devBusyCnt` overflow path was hit inside the `default:` completion case,
the code did `goto wait_for_completion` after already removing the IRP from
`L2CompletionQueue`, without releasing its RemoveLock.  Because the thread
exit cleanup loop only drains items still **in** `L2CompletionQueue`, this
lock was never released, causing `IoReleaseRemoveLockAndWait` to hang
indefinitely on the next device removal attempt.

### Fix

**Lock lifetime**: Acquire the RemoveLock immediately before `IoCallDriver`
and release it only after the thread has finished all access to `pDevExt`
that is triggered by the IRP (i.e., at the end of completion processing in
the thread's event loop, not inside the DPC-level completion callback).

**Acquisition placement** (`USBMRD.c`): The acquire is placed *before* any
buffer state mutation (`L2BUF_STATE_PENDING`, `InsertTailList` into
`L2PendingQueue`, `InterlockedIncrement` of `NumberOfPendingReadIRPs`).
This eliminates the need for any rollback: if acquisition fails the device
is already being removed, so `bL2Stopped = TRUE; break` is sufficient.

**Release coverage** (both files): Every code path that exits the
per-IRP processing block now calls `IoReleaseRemoveLock` with the matching
IRP tag before transferring control (`goto`, `continue`, or `break`).

**Thread exit drain** (`USBMRD.c`): After the main event loop exits,
any IRP completions that arrived while the CANCEL event was being processed
(and therefore never visited by the `default:` case) are drained from
`L2CompletionQueue` and their RemoveLocks released, preventing
`IoReleaseRemoveLockAndWait` from hanging.

### Testing

- Verified with static analysis (manual code path enumeration) that every
  `IoAcquireRemoveLock(pRemoveLock, pIrp)` call site has exactly one
  matching `IoReleaseRemoveLock(pRemoveLock, pIrp)` on all reachable paths,
  including error, cancellation, device-stopping, and thread-exit paths.
- No deadlocks: RemoveLock is held at PASSIVE_LEVEL; spinlocks
  (`L2Lock`, `ReadSpinLock`) are narrow-scope and never held while
  blocking on the RemoveLock.
- No double-releases: each IRP has a unique tag; the cleanup loop uses
  `pBuf->Irp` (the same tag used at acquisition).

- **Further testing on real devices is still needed**.

### Files Changed

| File | Description |
|------|-------------|
| `src/windows/transport/usb/USBMRD.c` | `USBMRD_L2MultiReadThread`: acquire lock before state changes; release on all completion paths; drain queue on thread exit |
| `src/windows/transport/usb/USBRD.c` | `QCUSB_ReadThread`: acquire lock before `IoCallDriver`; release on all three `L2_READ_COMPLETION_EVENT_INDEX` exit paths |