### PR TITLE
fix(ndis): populate CurrentCellularClass in WWAN_REGISTRATION_STATE for Win10+ target

### DIFF
--- a/src/windows/ndis/MPQMI.c
+++ b/src/windows/ndis/MPQMI.c
@@ -1145,7 +1145,7 @@ ULONG MPQMI_OIDtoQMI
                 pOID->OIDRespLen = sizeof(NDIS_WWAN_REGISTRATION_STATE);
                 pNdisRegisterState = (PNDIS_WWAN_REGISTRATION_STATE)pOID->pOIDResp;
                 pNdisRegisterState->Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
                 pNdisRegisterState->Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 
                 pOID->IndicationType = NDIS_STATUS_WWAN_REGISTER_STATE;

--- a/src/windows/ndis/MPQMUX.c
+++ b/src/windows/ndis/MPQMUX.c
@@ -1729,20 +1729,13 @@ VOID MPQMI_ProcessInboundQWDSIndication
 
                                 NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
                                 NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
                                 NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
-    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+                                NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+                                NdisRegisterState.RegistrationState.CurrentCellularClass =
+                                    (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
                                 NdisRegisterState.RegistrationState.RegisterState = WwanRegisterStateDeregistered;
                                 NdisRegisterState.RegistrationState.RegisterMode = pAdapter->RegisterMode;
 
@@ -17980,21 +17973,13 @@ ULONG MPQMUX_ProcessNasGetServingSystemResp
 
             NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
-    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+            NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+            NdisRegisterState.RegistrationState.CurrentCellularClass =
+                (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
-
             ParseNasGetServingSystem
             (
                 pAdapter,
@@ -18330,20 +18315,13 @@ ULONG MPQMUX_ProcessNasServingSystemInd
 
     NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
     NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+    NdisRegisterState.RegistrationState.CurrentCellularClass =
+        (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {
         char temp[1024];
@@ -20414,20 +20392,13 @@ ULONG MPQMUX_ProcessNasGetSysInfoResp
 
             NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
-    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+            NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+            NdisRegisterState.RegistrationState.CurrentCellularClass =
+                (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
 
             QCNET_DbgPrint
             (
@@ -20771,19 +20742,13 @@ ULONG MPQMUX_ProcessNasSysInfoInd
 
     NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
     NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+    NdisRegisterState.RegistrationState.CurrentCellularClass =
+        (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {

--- a/src/windows/ndis/MPQMUX.c
+++ b/src/windows/ndis/MPQMUX.c
@@ -1731,6 +1731,17 @@ VOID MPQMI_ProcessInboundQWDSIndication
                                 NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
                                 NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
                                 NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
                                 NdisRegisterState.RegistrationState.RegisterState = WwanRegisterStateDeregistered;
                                 NdisRegisterState.RegistrationState.RegisterMode = pAdapter->RegisterMode;
@@ -17971,6 +17982,17 @@ ULONG MPQMUX_ProcessNasGetServingSystemResp
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
 
             ParseNasGetServingSystem
@@ -18310,6 +18332,17 @@ ULONG MPQMUX_ProcessNasServingSystemInd
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
     NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {
@@ -20383,6 +20416,17 @@ ULONG MPQMUX_ProcessNasGetSysInfoResp
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
 
             QCNET_DbgPrint
@@ -20729,6 +20773,17 @@ ULONG MPQMUX_ProcessNasSysInfoInd
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
     NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {


### PR DESCRIPTION
## Problem

When building the qcusbnet (RMNET) driver with `TargetVersion=Windows10`, Windows 11 always reports **NO SERVICE** in Network Manager despite the modem being correctly registered on LTE. The QMI layer correctly parses NAS SysInfo TLVs and determines registration state, but the NDIS indication to Windows fails.

## Root Cause

The WDK header `wwan.h` conditionally adds fields to `WWAN_REGISTRATION_STATE` based on OS version:

```c
typedef struct _WWAN_REGISTRATION_STATE {
    ...
    WCHAR               RoamingText[WWAN_ROAMTEXT_LEN];
#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
    DWORD               WwanRegFlags;
    WWAN_CELLULAR_CLASS CurrentCellularClass;   // <-- NEVER SET
#endif
#if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
    ULONG               PreferredDataClasses;   // <-- NEVER SET
#endif
} WWAN_REGISTRATION_STATE;
```

With `TargetVersion=Windows10`, these fields are compiled into the struct. The driver does `NdisZeroMemory` but never populates `CurrentCellularClass` or `PreferredDataClasses`. Since `CurrentCellularClass=0` is not a valid `WWAN_CELLULAR_CLASS` value (valid: `WwanCellularClassGsm=1`, `WwanCellularClassCdma=2`), Windows 11 WWanSvc interprets this as no cellular technology available and reports NO SERVICE.

## Fix

After the `NdisZeroMemory` + NDIS_OBJECT_HEADER initialization of `NdisRegisterState`, populate the Win8+ conditional fields:
- Set `CurrentCellularClass` based on `pAdapter->DeviceClass` (GSM or CDMA)
- Set `WwanRegFlags` to `WWAN_REG_FLAGS_NONE`
- Set `PreferredDataClasses` to `WWAN_DATA_CLASS_LTE`

The fix is guarded by the same `#if` preprocessor conditionals used in the WDK header, so it compiles to nothing when `TargetVersion=Windows7`.

## Testing

- Build: Release/x64 with TargetVersion=Windows10 - **PASS** (no errors, no warnings)
- The fix is a no-op for Win7/Win8 target builds (guarded by preprocessor)

## Affected Locations

5 instances in `src/windows/ndis/MPQMUX.c` where `NDIS_WWAN_REGISTRATION_STATE` is initialized:
1. DUN call disconnect indication
2. NAS GetServingSystem response handler
3. NAS GetSysInfo response handler (primary path)
4. NAS SysInfo response (alternate path)
5. NAS SysInfo indication handler