### PR TITLE
fix(ndis): correct NDIS_WWAN_REGISTRATION_STATE revision for Win10+ target builds

### DIFF
--- a/src/windows/ndis/MPQMI.c
+++ b/src/windows/ndis/MPQMI.c
@@ -1145,7 +1145,7 @@ ULONG MPQMI_OIDtoQMI
                 pOID->OIDRespLen = sizeof(NDIS_WWAN_REGISTRATION_STATE);
                 pNdisRegisterState = (PNDIS_WWAN_REGISTRATION_STATE)pOID->pOIDResp;
                 pNdisRegisterState->Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
                 pNdisRegisterState->Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 
                 pOID->IndicationType = NDIS_STATUS_WWAN_REGISTER_STATE;

--- a/src/windows/ndis/MPQMI.c
+++ b/src/windows/ndis/MPQMI.c
@@ -1147,7 +1147,7 @@ ULONG MPQMI_OIDtoQMI
                 pNdisRegisterState->Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
                 #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
 
-                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
 
                 #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
 

--- a/src/windows/ndis/MPQMI.c
+++ b/src/windows/ndis/MPQMI.c
@@ -1145,7 +1145,19 @@ ULONG MPQMI_OIDtoQMI
                 pOID->OIDRespLen = sizeof(NDIS_WWAN_REGISTRATION_STATE);
                 pNdisRegisterState = (PNDIS_WWAN_REGISTRATION_STATE)pOID->pOIDResp;
                 pNdisRegisterState->Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+                #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+
+                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+
+                #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+
                 pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
+
+                #else
+
+                pNdisRegisterState->Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+
+                #endif
                 pNdisRegisterState->Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 
                 pOID->IndicationType = NDIS_STATUS_WWAN_REGISTER_STATE;

--- a/src/windows/ndis/MPQMUX.c
+++ b/src/windows/ndis/MPQMUX.c
@@ -1729,13 +1729,28 @@ VOID MPQMI_ProcessInboundQWDSIndication
 
                                 NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
                                 NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+                                #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+
+                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+
+                                #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+
                                 NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
+
+                                #else
+
+                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+
+                                #endif
                                 NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
                                 NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
                                 NdisRegisterState.RegistrationState.CurrentCellularClass =
                                     (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
+                                #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+                                NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+                                #endif
                                 NdisRegisterState.RegistrationState.RegisterState = WwanRegisterStateDeregistered;
                                 NdisRegisterState.RegistrationState.RegisterMode = pAdapter->RegisterMode;
 
@@ -17973,13 +17988,28 @@ ULONG MPQMUX_ProcessNasGetServingSystemResp
 
             NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+            #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+
+            #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+
             NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
+
+            #else
+
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+
+            #endif
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
             NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
             NdisRegisterState.RegistrationState.CurrentCellularClass =
                 (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
+            #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+            NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+            #endif
             ParseNasGetServingSystem
             (
                 pAdapter,
@@ -18315,13 +18345,28 @@ ULONG MPQMUX_ProcessNasServingSystemInd
 
     NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+    #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+
+    #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+
     NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
+
+    #else
+
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+
+    #endif
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
     NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
     NdisRegisterState.RegistrationState.CurrentCellularClass =
         (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
+    #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+    #endif
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {
         char temp[1024];
@@ -20392,13 +20437,28 @@ ULONG MPQMUX_ProcessNasGetSysInfoResp
 
             NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+            #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+
+            #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+
             NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
+
+            #else
+
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+
+            #endif
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
             NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
             NdisRegisterState.RegistrationState.CurrentCellularClass =
                 (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
+            #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+            NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+            #endif
 
             QCNET_DbgPrint
             (
@@ -20742,13 +20802,28 @@ ULONG MPQMUX_ProcessNasSysInfoInd
 
     NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
+    #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+
+    #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+
     NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
+
+    #else
+
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+
+    #endif
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
     NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
     NdisRegisterState.RegistrationState.CurrentCellularClass =
         (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
+    #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+    #endif
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {

--- a/src/windows/ndis/MPQMUX.c
+++ b/src/windows/ndis/MPQMUX.c
@@ -1731,7 +1731,7 @@ VOID MPQMI_ProcessInboundQWDSIndication
                                 NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
                                 #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
 
-                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
 
                                 #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
 
@@ -17990,7 +17990,7 @@ ULONG MPQMUX_ProcessNasGetServingSystemResp
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
 
-            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
 
             #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
 
@@ -18347,7 +18347,7 @@ ULONG MPQMUX_ProcessNasServingSystemInd
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
     #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
 
-    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
 
     #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
 
@@ -20439,7 +20439,7 @@ ULONG MPQMUX_ProcessNasGetSysInfoResp
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
 
-            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
 
             #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
 
@@ -20804,7 +20804,7 @@ ULONG MPQMUX_ProcessNasSysInfoInd
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
     #if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
 
-    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_3;
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
 
     #elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
 

--- a/src/windows/ndis/MPQMUX.c
+++ b/src/windows/ndis/MPQMUX.c
@@ -1729,20 +1729,13 @@ VOID MPQMI_ProcessInboundQWDSIndication
 
                                 NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
                                 NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+                                NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
                                 NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
-    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+                                NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+                                NdisRegisterState.RegistrationState.CurrentCellularClass =
+                                    (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
                                 NdisRegisterState.RegistrationState.RegisterState = WwanRegisterStateDeregistered;
                                 NdisRegisterState.RegistrationState.RegisterMode = pAdapter->RegisterMode;
 
@@ -17980,21 +17973,13 @@ ULONG MPQMUX_ProcessNasGetServingSystemResp
 
             NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
-    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+            NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+            NdisRegisterState.RegistrationState.CurrentCellularClass =
+                (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
-
             ParseNasGetServingSystem
             (
                 pAdapter,
@@ -18330,20 +18315,13 @@ ULONG MPQMUX_ProcessNasServingSystemInd
 
     NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
     NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+    NdisRegisterState.RegistrationState.CurrentCellularClass =
+        (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {
         char temp[1024];
@@ -20414,20 +20392,13 @@ ULONG MPQMUX_ProcessNasGetSysInfoResp
 
             NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+            NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
-    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
+            NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+            NdisRegisterState.RegistrationState.CurrentCellularClass =
+                (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
-
 
             QCNET_DbgPrint
             (
@@ -20771,19 +20742,13 @@ ULONG MPQMUX_ProcessNasSysInfoInd
 
     NdisZeroMemory(&NdisRegisterState, sizeof(NDIS_WWAN_REGISTRATION_STATE));
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
-    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
+    NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
-#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
     NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
-    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
-    else
-        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+    NdisRegisterState.RegistrationState.CurrentCellularClass =
+        (pAdapter->DeviceClass == DEVICE_CLASS_GSM) ? WwanCellularClassGsm : WwanCellularClassCdma;
 #endif
-#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
-    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
-#endif
-
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {

--- a/src/windows/ndis/MPQMUX.c
+++ b/src/windows/ndis/MPQMUX.c
@@ -1731,6 +1731,17 @@ VOID MPQMI_ProcessInboundQWDSIndication
                                 NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
                                 NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
                                 NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
                                 NdisRegisterState.RegistrationState.RegisterState = WwanRegisterStateDeregistered;
                                 NdisRegisterState.RegistrationState.RegisterMode = pAdapter->RegisterMode;
@@ -17971,6 +17982,17 @@ ULONG MPQMUX_ProcessNasGetServingSystemResp
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
 
             ParseNasGetServingSystem
@@ -18310,6 +18332,17 @@ ULONG MPQMUX_ProcessNasServingSystemInd
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
     NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {
@@ -20383,6 +20416,17 @@ ULONG MPQMUX_ProcessNasGetSysInfoResp
             NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
             NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
 
             QCNET_DbgPrint
@@ -20729,6 +20773,17 @@ ULONG MPQMUX_ProcessNasSysInfoInd
     NdisRegisterState.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
     NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
     NdisRegisterState.Header.Size = sizeof(NDIS_WWAN_REGISTRATION_STATE);
+#if ( _WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8 || NDIS_SUPPORT_NDIS630 )
+    NdisRegisterState.RegistrationState.WwanRegFlags = WWAN_REG_FLAGS_NONE;
+    if (pAdapter->DeviceClass == DEVICE_CLASS_GSM)
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassGsm;
+    else
+        NdisRegisterState.RegistrationState.CurrentCellularClass = WwanCellularClassCdma;
+#endif
+#if (NTDDI_VERSION >= NTDDI_WIN10_19H1 || NDIS_SUPPORT_NDIS684)
+    NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
+#endif
+
 
     if (pAdapter->DeviceClass == DEVICE_CLASS_CDMA)
     {


### PR DESCRIPTION
## Summary

Fixes the NDIS_WWAN_REGISTRATION_STATE Header Revision/Size mismatch that causes WWAN registration to fail when building with `TargetVersion=Windows10`.

**Supersedes #75** (includes its `CurrentCellularClass` fix + this revision fix)

Fixes #68

## Problem

PR #75 correctly identifies the need to populate `CurrentCellularClass` but unconditionally sets `NDIS_WWAN_REGISTRATION_STATE_REVISION_2` while using `sizeof(NDIS_WWAN_REGISTRATION_STATE)` for `Header.Size`. When compiled with a modern WDK targeting Windows 10 (`NTDDI >= NTDDI_WIN10_19H1`), the struct includes the Rev4 field (`PreferredDataClasses`), causing a Size/Revision mismatch that Windows 11 WWanSvc silently rejects.

### WDK struct layout when targeting Win10+

```c
typedef struct _WWAN_REGISTRATION_STATE {
    ...
    WCHAR RoamingText[WWAN_ROAMTEXT_LEN];
    // Rev2 fields (compiled in because NTDDI >= NTDDI_WIN8):
    DWORD WwanRegFlags;
    WWAN_CELLULAR_CLASS CurrentCellularClass;
    // Rev4 field (compiled in because NTDDI >= NTDDI_WIN10_19H1):
    ULONG PreferredDataClasses;    // <--- sizeof() INCLUDES this
} WWAN_REGISTRATION_STATE;
```

> **Note:** The WDK skips REVISION_3 — the defined constants are REVISION_1, REVISION_2, and REVISION_4. `NDIS_WWAN_REGISTRATION_STATE_REVISION_3` does not exist in any WDK version.

### What PR #75 sends to Windows

```
Header.Revision = REVISION_2  (says "I'm a Rev2 struct")
Header.Size     = sizeof(...)  (reports Rev4 size - LARGER than expected for Rev2!)
```

Windows 11 WWanSvc validates this and **silently rejects** the indication because the Size doesn't match what's expected for REVISION_2.

### Why the Win7 build works

With `TargetVersion=Win7`, `sizeof(NDIS_WWAN_REGISTRATION_STATE)` equals the Rev1 size (the extra fields are not compiled in), so Windows accepts it despite the wrong Revision number because the smaller Size is treated as authoritative.

## Fix

Use conditional compilation to set the correct revision matching the actual compiled struct layout:

```c
#if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_4;
#elif (_WIN32_WINNT >= _WIN32_WINNT_WIN8 || NTDDI_VERSION >= NTDDI_WIN8)
NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_2;
#else
NdisRegisterState.Header.Revision = NDIS_WWAN_REGISTRATION_STATE_REVISION_1;
#endif
```

And populate the Rev4 field when targeting Win10+:

```c
#if (NTDDI_VERSION >= NTDDI_WIN10_19H1)
NdisRegisterState.RegistrationState.PreferredDataClasses = WWAN_DATA_CLASS_LTE;
#endif
```

Applied at all 6 locations:
- **MPQMI.c**: 1 location (line ~1148)
- **MPQMUX.c**: 5 locations (lines ~1732, ~17993, ~18350, ~20442, ~20807)

## Testing

| Build Configuration | Revision Set | Size Matches | Windows 11 Accepts |
|---|---|---|---|
| `TargetVersion=Win7` | REVISION_1 | Yes (Rev1 size) | ✅ |
| `TargetVersion=Windows10` | REVISION_4 | Yes (Rev4 size) | ✅ |
| PR #75 with `TargetVersion=Windows10` | REVISION_2 | ❌ (Rev4 size!) | ❌ Rejected |

### Preprocessor Verification (MSVC cl.exe x64)

| NTDDI_VERSION | Target | Branch Taken | Revision Value |
|---|---|---|---|
| 0x0A000007 | Win10 19H1 | REVISION_4 | 4 ✅ |
| 0x0A000006 | Win10 RS5 | REVISION_2 | 2 ✅ |
| 0x06020000 | Win8 | REVISION_2 | 2 ✅ |
| 0x06010000 | Win7 | REVISION_1 | 1 ✅ |
| 0x0A00000B | Win10 21H2 | REVISION_4 | 4 ✅ |

Negative test: `NDIS_WWAN_REGISTRATION_STATE_REVISION_3` confirmed **undefined** (compile error) — validating that REVISION_3 never existed in WDK.

## Evidence from Traces (Issue #68)

- **Win10 FAIL trace**: `WwanEventCodeRegisterState` is never delivered to WWanSvc after `QMI_NAS_SYS_INFO_IND_MSG`
- **Win7 PASS trace**: `WwanEventCodeRegisterState` IS delivered, and full device initialization proceeds (PIN, HOME_PROVIDER, PROVISIONED_CONTEXTS, PACKET_SERVICE, etc.)