### PR TITLE
fix: use qdinstall -u instead of -x to prevent self-deletion during uninstall

### DIFF
--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -346,10 +346,10 @@ namespace PayloadInstaller
             if (File.Exists(QdinstallExe))
             {
                 Print("\nRemoving current installation: " + QdinstallExe);
-                LogLine("[STEP] Invoking qdinstall.exe -x");
-                result = RunCommand(QdinstallExe, "-x");
+                LogLine("[STEP] Invoking qdinstall.exe -u");
+                result = RunCommand(QdinstallExe, "-u");
                 if (result != 0)
-                    LogLine("[WARN] qdinstall.exe -x returned: " + result + " (continuing)");
+                    LogLine("[WARN] qdinstall.exe -u returned: " + result + " (continuing)");
             }
             else
             {


### PR DESCRIPTION
### Problem

The installer was calling `qdinstall.exe -x` during the uninstall and pre-install
cleanup steps. The `-x` flag uninstalls the drivers **and deletes the installation
directory**, which is the same directory `qdinstall.exe` itself lives in. This caused
a failure mid-operation — the process would delete the files it needed to complete
the reinstall, leaving the system in a broken state where drivers could neither be
cleanly removed nor freshly installed.

### Fix

Replaced `qdinstall.exe -x` with `qdinstall.exe -u` in `RemoveCurrentInstallation()`.

The `-u` flag uninstalls the drivers only, leaving the installation directory intact.
The installer then handles directory cleanup itself via `Directory.Delete()` after
`qdinstall.exe` has exited cleanly, before extracting and installing the fresh payload.

### Test Result
<img width="455" height="127" alt="Image" src="https://github.com/user-attachments/assets/a0a008ce-6f19-4398-b8f9-4d72a2022ade" />. 

Fixes: #77 