### PR TITLE
build scripts: process optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,11 @@ RCa*
 *.ddf
 *.sys
 *.pdb
+*.zip
+*.cab
 build/target/
 src/linux/build
 
 # Attestation secrets
 build/attestation/authconfig.json
+build/attestation/sdcm-src

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -81,8 +81,8 @@ function Assert-DriversSigned {
             continue
         }
 
-        # signtool verify /pa = verify against default auth policy (works for both EV and attested)
-        $result = & $signtool verify /pa /q $fullPath 2>&1
+        # signtool verify /kp = verify against kernel-mode driver signing policy (WHQL only)
+        $result = & $signtool verify /kp /q $fullPath 2>&1
         if ($LASTEXITCODE -ne 0) {
             $unsigned += $rel
             Write-Host "[UNSIGNED] $rel" -ForegroundColor Red
@@ -96,17 +96,14 @@ function Assert-DriversSigned {
     if ($missing.Count -gt 0) {
         Write-Host "[ERROR] The following required files are missing:" -ForegroundColor Red
         $missing | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
-        Write-Host ""
+        Write-Host "[ERROR] Catalog file integrity verification failed. Please try rebuilding the drivers. `n" -ForegroundColor Red
+        exit 1
     }
 
     if ($unsigned.Count -gt 0) {
         Write-Host "[ERROR] The following files are not signed:" -ForegroundColor Red
         $unsigned | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
-        Write-Host ""
-    }
-
-        if ($missing.Count -gt 0 -or $unsigned.Count -gt 0) {
-        Write-Host "[ERROR] Catalog signature verification failed. Run AttestDrivers.bat to get Microsoft-attested .cat files before building the installer." -ForegroundColor Red
+        Write-Host "[ERROR] WHQL signature verification failed. Please run AttestDrivers.bat to get WHQL sign for all .cat files before building the installer. `n" -ForegroundColor Red
         exit 1
     }
 

--- a/build/build_drivers.bat
+++ b/build/build_drivers.bat
@@ -6,29 +6,13 @@ setlocal enabledelayedexpansion
 
 set "SCRIPT_DIR=%~dp0"
 set "BUILD_ROOT=%SCRIPT_DIR%target"
-set "NO_SIGN=0"
 
-for %%A in (%*) do (
-    if /i "%%A"=="--no_sign_required" set "NO_SIGN=1"
-)
-
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\build_drivers.ps1" -OutputTo "%BUILD_ROOT%"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%build_drivers.ps1" -OutputTo "%BUILD_ROOT%"
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\sign.ps1" -InputFrom "%BUILD_ROOT%"
-if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%sign.ps1"
+if %ERRORLEVEL% neq 0 echo [WARNING] EV-sign failed, unsigned drivers are built.
 
-if "%NO_SIGN%"=="1" (
-    echo [INFO] --no_sign_required set: skipping EV signing and attestation.
-    call "%SCRIPT_DIR%build_installer.bat" --no_sign_required
-) else (
-    call "%SCRIPT_DIR%attestation\AttestDrivers.bat"
-    if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!
-    call "%SCRIPT_DIR%build_installer.bat"
-)
-if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-:done
 echo [DONE] Output: %BUILD_ROOT%
 
 endlocal

--- a/build/sign.ps1
+++ b/build/sign.ps1
@@ -16,7 +16,7 @@ $Script:DefaultInputRoot = "target"
 $Script:InputSubDir = "drivers"
 
 # Whether to recurse into subdirectories when scanning for signable files
-$Script:Recurse = $false
+$Script:Recurse = $true
 
 # Supported file extensions for signing
 $Script:SignableExtensions = @(".cat", ".exe", ".sys", ".cab")
@@ -134,7 +134,7 @@ function Sign-EvServer {
 # Returns the CAB file path on success, or $false on failure.
 function Make-Cabinet {
     param(
-        [Parameter(Mandatory)][string]$SourceDir,   # e.g. target\Drivers\Windows10
+        [Parameter(Mandatory)][string]$SourceDir,   # e.g. target\drivers
         [Parameter(Mandatory)][string]$OutputDir    # e.g. target
     )
 
@@ -249,24 +249,25 @@ function Main {
     }
 
     # --- Batch mode (directory) ---
-    $outputDir = $inputPath
-    $driverDir = Join-Path $inputPath $Script:InputSubDir
+    if (-not $InputFrom) {
+        # sign target\drivers, then package into CAB
+        $outputDir = $inputPath                                # target
+        $inputPath = Join-Path $inputPath $Script:InputSubDir  # target\drivers
+    }
 
-    Write-Host "[INFO] Batch mode"
-
-    if (-not (Test-Path $driverDir)) {
-        Write-Host "[ERROR] Driver directory not found: $driverDir" -ForegroundColor Red
+    if (-not (Test-Path $inputPath)) {
+        Write-Host "[ERROR] Driver directory not found: $inputPath" -ForegroundColor Red
         exit 1
     }
 
-    $files = @(Get-ChildItem $driverDir -Recurse:$Script:Recurse -File |
+    $files = @(Get-ChildItem $inputPath -Recurse:$Script:Recurse -File |
         Where-Object { $_.Extension.ToLower() -in $Script:SignableExtensions })
 
     if ($files.Count -eq 0) {
         Write-Host "[WARN] No signable files found." -ForegroundColor Yellow
         exit 0
     }
-    Write-Host "[INFO] $($files.Count) file(s) found in $driverDir"
+    Write-Host "[INFO] $($files.Count) file(s) found in $inputPath"
     Write-Host ""
 
     Write-Host "[INFO] Starting EV signing...`n" -ForegroundColor Cyan
@@ -278,19 +279,22 @@ function Main {
         Write-Host ""
     }
 
-    Write-Host "[INFO] Creating CAB from $driverDir`n" -ForegroundColor Cyan
-    $cabPath = Make-Cabinet -SourceDir $driverDir -OutputDir $outputDir
-    if (-not $cabPath) {
-        Write-Host "[ERROR] CAB creation failed." -ForegroundColor Red
-        exit 1
-    }
-    Write-Host ""
+    # Generates DDF/CAB for the default mode
+    if (-not $InputFrom) {
+        Write-Host "[INFO] Creating CAB from $inputPath`n" -ForegroundColor Cyan
+        $cabPath = Make-Cabinet -SourceDir $inputPath -OutputDir $outputDir
+        if (-not $cabPath) {
+            Write-Host "[ERROR] CAB creation failed." -ForegroundColor Red
+            exit 1
+        }
+        Write-Host ""
 
         if (-not (Sign-EvServer -File $cabPath)) {
-        Write-Host "[ERROR] EV signing failed." -ForegroundColor Red
-        exit 1
+            Write-Host "[ERROR] EV signing failed." -ForegroundColor Red
+            exit 1
+        }
+        Write-Host ""
     }
-    Write-Host ""
 
     Write-Host "[OK] All files signed successfully." -ForegroundColor Green
     exit 0

--- a/build/sign.ps1
+++ b/build/sign.ps1
@@ -227,7 +227,7 @@ function Main {
     }
     $inputPath = (Resolve-Path $inputPath).Path
 
-        # --- Single file mode ---
+    # --- Single file mode ---
     if (Test-Path $inputPath -PathType Leaf) {
         $ext = [IO.Path]::GetExtension($inputPath).ToLower()
         Write-Host "[INFO] Sign file: $inputPath"


### PR DESCRIPTION
### Summary

1. Updated .gitignore to exclude SDCM related files.
2. Replaced /pa with /kp to make sure only WHQL signature is allowed.
3. Updated come debug messages
4. Updated sign.ps1 to reclusively sign all .sys and .cat files
5. Updated sign.ps1 to allow the sign of files and folders outside project
6. Removed attestation signing from build_drivers.bat. Users can still run AttestDrivers.bat to do attestation signing.


### Test

1. Full build tests are performed on arm64 and x64 machines.
2. Microsoft attestation signing passes.
3. AI static analysis reported no issues.