### PR TITLE
Updated the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,101 @@
 # Qualcomm USB Kernel Drivers
+
 Qualcomm kernel drivers provide logical representations of Qualcomm chipset-enabled mobile devices over USB connections. This repository includes source code, build scripts, and documentation for a set of device drivers designed for Qualcomm hardware platforms. The drivers support both Windows and Linux environments.
 The project is organized to facilitate easy compilation, testing, and integration into custom hardware solutions.
 
 ## Key Features
-  - Supports Windows and Linux platforms.
-  - Supports X64/X86/ARM64 architectures.
-  - WHQL-certified on the latest Windows operating systems.
-  - Compatible with Qualcomm tools like QUTS, QXDM, PCAT, and more.
-  - Compatible with terminal emulators like PuTTY and Tera Term.
-    
+
+- Supports Windows and Linux platforms.
+- Supports X64/X86/ARM64 architectures.
+- WHQL-certified on the latest Windows operating systems.
+- Compatible with Qualcomm tools like QUTS, QXDM, PCAT, and more.
+- Compatible with terminal emulators like PuTTY and Tera Term.
+
 ## Repository Structure
 
 ```
 /
 ├─ docs/                  # Architecture diagrams and design documents
 ├─ src/                   # Qualcomm USB kernel driver for windows and linux platform
-├─ examples/              # samples scripts
+├─ examples/              # Sample scripts
 ├─ README.md              # This file
 └─ ...                    # Other files and directories
 ```
 
-## Build Instructions
+---
 
-### Prerequisites
+# Windows
 
-#### Windows
+## Prerequisites
 
 - Visual Studio 2019 (or later) with **Desktop development with C++** workload.
 - Windows Driver Kit for Windows 10, version 1903 (18362.1) or later.
+- .NET Framework 4 (required by the installer build step).
 
-#### Linux
+## Build
 
-- GNU Make, GCC/Clang.
-- Kernel headers for the target kernel version (`linux-headers-$(uname -r)`).
-  
-### Build Steps
-
-#### Windows
-1. Clone the repository
+1. Clone the repository:
    ```bash
    git clone https://github.com/qualcomm/qcom-usb-kernel-drivers.git
    ```
-2. Navigate to directory where the code was cloned
+2. Open a Command Prompt and navigate to the `build` directory:
    ```bash
-   cd /src/windows/<project-name>
+   cd build
    ```
-3. From the project root, open the .vcxproj file in Visual Studio.
+3. Run the build script with the `--no_sign_required` flag:
+   ```bash
+   build_drivers.bat --no_sign_required
+   ```
 
-4. In Visual Studio, select `Build` > `Build Solution` from the top menu.
+This will build the drivers and tools for all supported architectures (x86, x64, arm64) and produce a self-contained installer executable for each:
 
-The output binaries are generated in a path depends on the chosen build configuration. For example:
+```
+build\target\qcom_usb_kernel_drivers_x86.exe
+build\target\qcom_usb_kernel_drivers_x64.exe
+build\target\qcom_usb_kernel_drivers_arm64.exe
+```
 
-    <ProjectRootDir>\x64\Debug\
-    <ProjectRootDir>\x64\Release\
-      
-#### Linux
+> **Note:** The `--no_sign_required` flag skips the Microsoft attestation signature check on the driver catalog files, which is useful for local testing without a signing certificate.
+
+## Install / Uninstall
+
+Use the installer executable generated for your target architecture. The installer must be run from an **elevated (Administrator) Command Prompt**.
+
+### Installation
+
+```bash
+qcom_usb_kernel_drivers_<arch>.exe --install
+```
+
+For example, to install on a 64-bit system:
+```bash
+qcom_usb_kernel_drivers_x64.exe --install
+```
+
+### Uninstallation
+
+```bash
+qcom_usb_kernel_drivers_<arch>.exe --uninstall
+```
+
+For example:
+```bash
+qcom_usb_kernel_drivers_x64.exe --uninstall
+```
+
+> **Note:** Installation logs are saved to `%ProgramData%\Qualcomm\QUD\` for troubleshooting.
+
+---
+
+# Linux
+
+## Prerequisites
+
+- GNU Make, GCC/Clang.
+- Kernel headers for the target kernel version (`linux-headers-$(uname -r)`).
+
+## Build
+
 ```bash
 cd src/linux
 make
@@ -62,42 +103,23 @@ make
 
 ## Install / Uninstall
 
-#### Windows
-- Installation
+Navigate to the `src/linux` folder.
 
-  Right click the `.inf` file in output folder and select **Install**.
-  Or install via command line `pnputil`:
-```bash
-pnputil /add-driver <build_path/driver_name.inf> /install
-```
-- Uninstallation (Device Manager)
-1. Open **Device Manager**.
-2. Right click the target device and select **Uninstall device**.
-3. Check **Attempt to remove the driver for this device**.
-4. Click **Uninstall**.
+### Installation
 
-- Uninstallation (Command Line)
-
-1. Locate the **Published Name** of the installed driver package:
-  ```bash
-  pnputil /enum-drivers
-  ```
-2. Delete the driver from system
-  ```bash
-  pnputil /delete-driver oemxx.inf /uninstall /force
-  ```
-#### Linux command:
-  Navigate to folder `src/linux`
-    
-- Installation
 ```bash
 sudo ./qcom_drivers.sh install
 ```
-- Uninstallation
+
+### Uninstallation
+
 ```bash
 sudo ./qcom_drivers.sh uninstall
 ```
-For more guidance on build process, FAQ's and troubleshooting, please refer to [README](./src/linux/README.md) document. 
+
+For more guidance on the build process, FAQs, and troubleshooting, please refer to the [Linux README](./src/linux/README.md).
+
+---
 
 ## Contributing
 
@@ -108,9 +130,9 @@ For more guidance on build process, FAQ's and troubleshooting, please refer to [
 
 Please follow the existing coding style and run the appropriate static analysis tools before submitting.
 
-## Bug & Vulnerability reporting
+## Bug & Vulnerability Reporting
 
-Please review the [security](./SECURITY.md) before reporting vulnerabilities with the project
+Please review the [security policy](./SECURITY.md) before reporting vulnerabilities with the project.
 
 ## Contributor's License Agreement
 
@@ -119,4 +141,4 @@ and conditions before contributing.
 
 ## Contact
 
-For questions, bug reports, or feature requests, please open an issue on GitHub or contact the maintainers
+For questions, bug reports, or feature requests, please open an issue on GitHub or contact the maintainers.


### PR DESCRIPTION
Reorganises README.md to improve clarity and reflect the current Windows build workflow.

Changes:

Split build and install/uninstall instructions into top-level # Windows and # Linux sections, each with their own Prerequisites, Build, and Install/Uninstall sub-sections
Updated Windows build steps to use build_installer.bat --no_sign_required instead of the previous manual Visual Studio workflow
Replaced Windows install/uninstall instructions (previously pnputil/Device Manager) with the generated installer executables (qcom_usb_kernel_drivers_<arch>.exe --install/--uninstall)
Added .NET Framework 4 to Windows prerequisites
Added notes on what --no_sign_required does and where installation logs are saved
Minor formatting fixes (bullet style, heading capitalisation)