### PR TITLE
Enable/Disable userspace based on QUD driver installation

### DIFF
--- a/src/linux/qcom_drivers.sh
+++ b/src/linux/qcom_drivers.sh
@@ -37,6 +37,7 @@ BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 RESET='\033[0m'
 IN_DPKG_MAINTSCRIPT="${DPKG_MAINTSCRIPT_PACKAGE:-}"
+QCOM_USERSPACE_SUPPORT_CONFIG_PATH=/etc/qcom_drivers.conf
 
 # Since Debian package installation already holds the dpkg front‑end lock (used by apt-get),
 # this script must not install dependencies when invoked by a parent dpkg process.
@@ -414,6 +415,9 @@ else
       fi
 	   # update modules.dep and modules.alias
       depmod
+
+      $QCOM_LN_RM_MK_DIR/rm -f $QCOM_USERSPACE_SUPPORT_CONFIG_PATH
+      echo -e "Enable Qualcomm Userspace Support"
 
 	   echo -e "Uninstallation completed successfully."
       exit 0
@@ -1236,6 +1240,10 @@ echo -e "Qualcomm Modem driver is installed at $DEST_MODEM_SERIAL_PATH"
 echo -e "Qualcomm usbnet driver is installed at $DEST_QCOM_USBNET_PATH"
 echo -e "Qualcomm usb driver is installed at $DEST_QCOM_USB_PATH"
 echo -e "Qualcomm udev naming/permission rules are installed at $QCOM_UDEV_PATH"
+
+echo "QCOM_USERSPACE_SUPPORT=0" > $QCOM_USERSPACE_SUPPORT_CONFIG_PATH
+echo -e "Disable Qualcomm Userspace driver support"
+
 
 if [ -f "$DEST_QUD_PATH/RELEASES.md" ]; then
    echo -e "QUD Release Notes available at $DEST_QUD_PATH/RELEASES.md"


### PR DESCRIPTION
## Description

Automatically toggle userspace driver support based on QUD kernel driver installation.

Starting with QUD Linux v1.0.6.6, installing the QUD kernel driver automatically disables userspace driver support.

Upon uninstallation of the QUD Linux kernel driver, the application automatically switches back to using the userspace driver by default

## Type of Change

<!-- Tick all that apply by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

<!--
Describe the tests you ran. Reviewers will ask for evidence - paste the
relevant snippets here.
-->

## Checklist

<!-- Replace [ ] with [x] for each item that's done. PRs missing items will be sent back for changes. -->

- [ ] **All required CI checks are green** on the latest commit of this PR
- [x] **Build succeeds** following the steps in the [README](../README.md) / [src/linux/README.md](../src/linux/README.md)
- [x] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [x] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `<branch-prefix>/<area>/<description>`
- [x] PR title follows the Conventional Commits format with our full-word types (`feature` / `bugfix` / `hotfix` / `docs`)
- [x] I have performed a **self-review** of my own code
- [x] I have added **code comments** in areas that are complex or hard to understand
- [x] My changes generate **no new compiler warnings**
- [x] I have added **tests** for my fix or feature (or noted why tests are not feasible)
- [ ] New and existing **tests pass locally** with my changes
- [x] My branch is **rebased onto the latest `develop`** (or `release/x.y` for hotfix) - no merge commits
- [x] Every commit has `Signed-off-by:` (DCO) - see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-guidelines)
- [ ] I have **linked** the relevant issue if any (`Fixes #...`)
- [ ] Any dependent changes have been merged and published in downstream modules
