### PR TITLE
ndis: force Windows 7 driver model reporting to work around LTE registration issue on Windows 10/11

### DIFF
--- a/src/windows/ndis/MPOID.c
+++ b/src/windows/ndis/MPOID.c
@@ -1386,8 +1386,8 @@ NDIS_STATUS MPOID_QueryInformation
             driverCaps.Header.Type = NDIS_OBJECT_TYPE_DEFAULT;
             driverCaps.Header.Revision = NDIS_WWAN_DRIVER_CAPS_REVISION_1;
             driverCaps.Header.Size = sizeof(NDIS_WWAN_DRIVER_CAPS);
-            driverCaps.DriverCaps.ulMajorVersion = WWAN_MAJOR_VERSION;
-            driverCaps.DriverCaps.ulMinorVersion = WWAN_MINOR_VERSION;
+            driverCaps.DriverCaps.ulMajorVersion = WWAN_MAJOR_VERSION_1;
+            driverCaps.DriverCaps.ulMinorVersion = WWAN_MINOR_VERSION_0;
             MPOID_GetInformation(&pInfo, &ulInfoLen, &driverCaps, sizeof(NDIS_WWAN_DRIVER_CAPS));
             break;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Qualcomm Open Source Project!
Please read CONTRIBUTING.md before submitting:
https://github.com/qualcomm/qcom-usb-kernel-drivers/blob/develop/CONTRIBUTING.md

Title format (Conventional Commits, full words):
  <type>/<scope>: <short summary>
Examples:
  feature/qcom_usbnet: add retry logic for transient errors
-->

## Description

Fix for issue [[NDIS] Windows 11 Network Manager reports NO SERVICE with TargetVersion=Windows10 despite LTE registration
](https://github.com/qualcomm/qcom-usb-kernel-drivers/issues/68)

## Type of Change

<!-- Tick all that apply by replacing [ ] with [x]. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

This fix has been tested and confirmed working by issue raiser.

Tried building with WDK 19061 and 26100 on x64 and arm64, target platform Windows 10, no issue is found.

## Checklist

<!-- Replace [ ] with [x] for each item that's done. PRs missing items will be sent back for changes. -->

- [x] **All required CI checks are green** on the latest commit of this PR
- [x] **Build succeeds** following the steps in the [README](../README.md) / [src/linux/README.md](../src/linux/README.md)
- [ ] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [ ] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `<branch-prefix>/<area>/<description>`
- [ ] PR title follows the Conventional Commits format with our full-word types (`feature` / `bugfix` / `hotfix` / `docs`)
- [ ] I have performed a **self-review** of my own code
- [ ] I have added **code comments** in areas that are complex or hard to understand
- [ ] My changes generate **no new compiler warnings**
- [ ] I have added **tests** for my fix or feature (or noted why tests are not feasible)
- [ ] New and existing **tests pass locally** with my changes
- [ ] My branch is **rebased onto the latest `develop`** (or `release/x.y` for hotfix) - no merge commits
- [ ] Every commit has `Signed-off-by:` (DCO) - see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-guidelines)
- [ ] I have **linked** the relevant issue if any (`Fixes #...`)
- [ ] Any dependent changes have been merged and published in downstream modules
