### PR TITLE
qcwwan: fix NULL pointer dereference BSOD during concurrent 5G module reset [Case#08589733]

### DIFF
--- a/src/windows/transport/usb/USBMRD.c
+++ b/src/windows/transport/usb/USBMRD.c
@@ -826,6 +826,25 @@ void USBMRD_L2MultiReadThread(PDEVICE_EXTENSION pDevExt)
                     NULL
                 )
 
+                // Acquire RemoveLock before calling IoCallDriver so that pDevExt
+                // cannot be freed by IoReleaseRemoveLockAndWait for the entire
+                // duration of this L2 IRP. A failed return value indicates that
+                // the device is in the process of being removed; therefore, the
+                // L2 thread should terminate.
+                ntStatus = IoAcquireRemoveLock(pDevExt->pRemoveLock, pIrp);
+                if (!NT_SUCCESS(ntStatus))
+                {
+                    QCUSB_DbgPrint
+                    (
+                        QCUSB_DBG_MASK_READ,
+                        QCUSB_DBG_LEVEL_CRITICAL,
+                        ("<%s> ML2: AcquireRemoveLock failed 0x%x, device removing\n",
+                        pDevExt->PortName, ntStatus)
+                    );
+                    pDevExt->bL2Stopped = TRUE;
+                    break;
+                }
+
                     pDevExt->pL2ReadBuffer[pDevExt->L2IrpEndIdx].State = L2BUF_STATE_PENDING;
 
                 //PendingQueue
@@ -1373,6 +1392,7 @@ wait_for_completion:
                                     IO_NO_INCREMENT,
                                     FALSE
                                 );
+                                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                                 goto wait_for_completion;
                             }
                             if (inDevState(DEVICE_STATE_PRESENT_AND_STARTED))
@@ -1400,6 +1420,7 @@ wait_for_completion:
                     if (pActiveL2Buf != NULL)
                     {
                         IoCancelIrp(pActiveL2Buf->Irp);
+                        IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                         goto wait_for_completion;
                     }
                     else
@@ -1438,6 +1459,7 @@ wait_for_completion:
                     pDevExt->bL2Stopped = TRUE;
                 }
 
+                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                 break;
             }  // default
 
@@ -1467,11 +1489,16 @@ wait_for_completion:
         pDevExt->hRxLogFile = NULL;
     }
 
-    // Empty the L2 completion queue
+    // Drain the L2 completion queue and release any RemoveLocks that were
+    // acquired when each IRP was submitted but whose completions were never
+    // processed by the main loop.
     QcAcquireSpinLock(&pDevExt->L2Lock, &levelOrHandle);
     while (!IsListEmpty(&pDevExt->L2CompletionQueue))
     {
+        PUSBMRD_L2BUFFER pBuf;
         headOfList = RemoveHeadList(&pDevExt->L2CompletionQueue);
+        pBuf = CONTAINING_RECORD(headOfList, USBMRD_L2BUFFER, List);
+        IoReleaseRemoveLock(pDevExt->pRemoveLock, pBuf->Irp);
     }
     QcReleaseSpinLock(&pDevExt->L2Lock, levelOrHandle);
 

--- a/src/windows/transport/usb/USBRD.c
+++ b/src/windows/transport/usb/USBRD.c
@@ -1167,6 +1167,25 @@ void QCUSB_ReadThread(PDEVICE_EXTENSION pDevExt)
                     NULL
                 )
                     QCPWR_CancelIdleTimer(pDevExt, QCUSB_BUSY_WT, TRUE, 20);  // RX in progress, set busy and cancel idle IRP
+
+                // Acquire RemoveLock before calling IoCallDriver so that pDevExt
+                // cannot be freed by IoReleaseRemoveLockAndWait for the entire
+                // duration of this L2 IRP. A failed return value indicates that
+                // the device is in the process of being removed; therefore, the
+                // L2 thread should terminate.
+                ntStatus = IoAcquireRemoveLock(pDevExt->pRemoveLock, pIrp);
+                if (!NT_SUCCESS(ntStatus))
+                {
+                    QCUSB_DbgPrint
+                    (
+                        QCUSB_DBG_MASK_READ,
+                        QCUSB_DBG_LEVEL_CRITICAL,
+                        ("<%s> L2: AcquireRemoveLock failed 0x%x, device is being removed\n",
+                        pDevExt->PortName, ntStatus)
+                    );
+                    pDevExt->bL2Stopped = TRUE;
+                    goto wait_for_completion;
+                }
                 pDevExt->bL2ReadActive = TRUE;
                 ntStatus = IoCallDriver(pDevExt->StackDeviceObject, pIrp);
                 if (ntStatus != STATUS_PENDING)
@@ -1373,6 +1392,7 @@ wait_for_completion:
                                     IO_NO_INCREMENT,
                                     FALSE
                                 );
+                                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                                 goto wait_for_completion;
                             }
                         }
@@ -1386,6 +1406,7 @@ wait_for_completion:
                         FALSE
                     );
 
+                    IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                     continue;
                 }
 
@@ -1402,6 +1423,7 @@ wait_for_completion:
                     pDevExt->bL2Stopped = TRUE;
                 }
 
+                IoReleaseRemoveLock(pDevExt->pRemoveLock, pIrp);
                 break;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Qualcomm Open Source Project!
Please read CONTRIBUTING.md before submitting:
https://github.com/qualcomm/qcom-usb-kernel-drivers/blob/develop/CONTRIBUTING.md

Title format (Conventional Commits, full words):
  <type>/<scope>: <short summary>
Examples:
  feature/qcom_usbnet: add retry logic for transient errors
-->

## Description

- Please refer to https://github.com/qualcomm/qcom-usb-kernel-drivers/pull/71 for full details about this issue.

On device removal, `IoReleaseRemoveLockAndWait` is supposed to drain all
outstanding `IoAcquireRemoveLock` calls before freeing `pDevExt`.  However,
the L2 USB read threads (`USBMRD_L2MultiReadThread` and `QCUSB_ReadThread`)
submitted IRPs to the USB stack via `IoCallDriver` **without** holding the
RemoveLock across the IRP lifetime.  This created a window where:

1. Device removal calls `IoReleaseRemoveLockAndWait`, which sees a zero
   outstanding count and proceeds to free `pDevExt`.
2. The USB completion handler (or the L2 thread processing the completion)
   is still running and dereferences the now-freed `pDevExt`.

Result: **use-after-free BSOD** on device hot-unplug or surprise removal.

A secondary issue existed in `USBMRD_L2MultiReadThread`: when the
`devBusyCnt` overflow path was hit inside the `default:` completion case,
the code did `goto wait_for_completion` after already removing the IRP from
`L2CompletionQueue`, without releasing its RemoveLock.  Because the thread
exit cleanup loop only drains items still **in** `L2CompletionQueue`, this
lock was never released, causing `IoReleaseRemoveLockAndWait` to hang
indefinitely on the next device removal attempt.

## Type of Change

<!-- Tick all that apply by replacing [ ] with [x]. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

- Verified with static analysis (manual code path enumeration) that every
  `IoAcquireRemoveLock(pRemoveLock, pIrp)` call site has exactly one
  matching `IoReleaseRemoveLock(pRemoveLock, pIrp)` on all reachable paths,
  including error, cancellation, device-stopping, and thread-exit paths.
- No deadlocks: RemoveLock is held at PASSIVE_LEVEL; spinlocks
  (`L2Lock`, `ReadSpinLock`) are narrow-scope and never held while
  blocking on the RemoveLock.
- No double-releases: each IRP has a unique tag; the cleanup loop uses
  `pBuf->Irp` (the same tag used at acquisition).

- **Further testing on real devices is still needed**.

## Checklist

<!-- Replace [ ] with [x] for each item that's done. PRs missing items will be sent back for changes. -->

- [x] **All required CI checks are green** on the latest commit of this PR
- [x] **Build succeeds** following the steps in the [README](../README.md) / [src/linux/README.md](../src/linux/README.md)
- [ ] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [ ] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `<branch-prefix>/<area>/<description>`
- [ ] PR title follows the Conventional Commits format with our full-word types (`feature` / `bugfix` / `hotfix` / `docs`)
- [ ] I have performed a **self-review** of my own code
- [ ] I have added **code comments** in areas that are complex or hard to understand
- [ ] My changes generate **no new compiler warnings**
- [ ] I have added **tests** for my fix or feature (or noted why tests are not feasible)
- [ ] New and existing **tests pass locally** with my changes
- [ ] My branch is **rebased onto the latest `develop`** (or `release/x.y` for hotfix) - no merge commits
- [ ] Every commit has `Signed-off-by:` (DCO) - see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-guidelines)
- [ ] I have **linked** the relevant issue if any (`Fixes #...`)
- [ ] Any dependent changes have been merged and published in downstream modules
