### PR TITLE
wdfserial: fix diag port re-enumeration by clearing DeviceRemoveEvent, incrementing QCDeviceGeneration, and refreshing ReportDeviceName on D0Entry

### DIFF
--- a/src/windows/wdfserial/QCMAIN.h
+++ b/src/windows/wdfserial/QCMAIN.h
@@ -401,6 +401,7 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(REQUEST_CONTEXT, QCReqGetContext)
 // Registry Value Names
 #define VEN_DEV_PORT        L"AssignedPortForQCDevice"
 #define VEN_DEV_TIME        L"QCDeviceStamp"
+#define VEN_DEV_GENERATION  L"QCDeviceGeneration"
 #define VEN_DEV_SERNUM      L"QCDeviceSerialNumber"
 #define VEN_DEV_MSM_SERNUM  L"QCDeviceMsmSerialNumber"
 #define VEN_DEV_PROTOC      L"QCDeviceProtocol"

--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -94,11 +94,6 @@ NTSTATUS QCPNP_EvtDeviceAdd
         goto exit;
     }
 
-    if (pDevContext->FdoDeviceType == FILE_DEVICE_SERIAL_PORT)
-    {
-        QCPNP_ReportDeviceName(pDevContext);
-    }
-
 exit:
     if (!NT_SUCCESS(status))
     {
@@ -265,6 +260,50 @@ NTSTATUS QCPNP_SetStamp
         WdfRegistryClose(key);
     }
     return STATUS_SUCCESS;
+}
+
+/****************************************************************************
+ *
+ * function: QCPNP_IncrementGeneration
+ *
+ * purpose:  Increments QCDeviceGeneration DWORD in the driver registry key
+ *           on every PrepareHardware so QDS can detect a re-enumeration even
+ *           when DevDesc/DevName/SerNum are identical across reboots.
+ *
+ * arguments:pDevContext = pointer to the device context.
+ *
+ * returns:  NT Status
+ *
+ ****************************************************************************/
+NTSTATUS QCPNP_IncrementGeneration(PDEVICE_CONTEXT pDevContext)
+{
+    NTSTATUS       status = STATUS_SUCCESS;
+    WDFDEVICE      device = pDevContext->Device;
+    WDFKEY         key;
+    ULONG          genValue = 0;
+    DECLARE_CONST_UNICODE_STRING(valueName, VEN_DEV_GENERATION);
+
+    status = WdfDeviceOpenRegistryKey(device, PLUGPLAY_REGKEY_DRIVER,
+        KEY_QUERY_VALUE | KEY_SET_VALUE, WDF_NO_OBJECT_ATTRIBUTES, &key);
+    if (!NT_SUCCESS(status))
+    {
+        return status;
+    }
+
+    WdfRegistryQueryValue(key, &valueName, REG_DWORD, &genValue, sizeof(genValue), NULL);
+    WdfRegistryClose(key);
+
+    genValue++;
+    status = QCMAIN_SetDriverRegistryDword((LPWSTR)valueName.Buffer, genValue, pDevContext);
+
+    QCSER_DbgPrint
+    (
+        QCSER_DBG_MASK_CONTROL,
+        QCSER_DBG_LEVEL_DETAIL,
+        ("<%ws> QCPNP_IncrementGeneration new generation: %lu, status: 0x%x\n",
+         pDevContext->PortName, genValue, status)
+    );
+    return status;
 }
 
 /****************************************************************************
@@ -1714,6 +1753,10 @@ NTSTATUS QCPNP_EvtDevicePrepareHardware
         status = QCPNP_RegisterWmiPowerGuid(pDevContext);
     }
 
+    // Increment QCDeviceGeneration so QDS can detect a re-enumeration even
+    // when the device identity (DevDesc/DevName/SerNum) is unchanged.
+    QCPNP_IncrementGeneration(pDevContext);
+
 exit:
     if (!NT_SUCCESS(status))
     {
@@ -2234,6 +2277,14 @@ NTSTATUS QCPNP_EvtDeviceD0Entry
         QCSER_DBG_LEVEL_TRACE,
         ("<%ws> QCPNP_EvtDeviceD0Entry Completed!\n", pDevContext->PortName)
     );
+
+    // Re-announce diag device name to parent/filter on every D0 entry.
+    // EvtDeviceAdd fires only once; D0Entry fires on each re-enumeration.
+    if (pDevContext->FdoDeviceType == FILE_DEVICE_SERIAL_PORT)
+    {
+        QCPNP_ReportDeviceName(pDevContext);
+    }
+
     return STATUS_SUCCESS;
 }
 
@@ -3279,6 +3330,9 @@ NTSTATUS QCPNP_SetupIoThreadsAndQueues
     NTSTATUS status;
     LARGE_INTEGER threadInitTimeout;
     threadInitTimeout.QuadPart = WDF_REL_TIMEOUT_IN_MS(QCPNP_THREAD_INIT_TIMEOUT_MS);
+
+    // Clear stale removal signal in case we're re-entering after a removal cycle
+    KeClearEvent(&pDevContext->DeviceRemoveEvent);
 
     // Init write request list, lock and events
     InitializeListHead(&pDevContext->WriteRequestPendingList);

--- a/src/windows/wdfserial/QCPNP.h
+++ b/src/windows/wdfserial/QCPNP.h
@@ -184,4 +184,9 @@ NTSTATUS QCPNP_SetStamp
     PDEVICE_CONTEXT pDevContext,
     BOOLEAN        Startup
 );
+
+NTSTATUS QCPNP_IncrementGeneration
+(
+    PDEVICE_CONTEXT pDevContext
+);
 #endif // QCPNP_H


### PR DESCRIPTION
<!--
Thank you for contributing to Qualcomm Open Source Project!
Please read CONTRIBUTING.md before submitting:
https://github.com/qualcomm/qcom-usb-kernel-drivers/blob/develop/CONTRIBUTING.md

Title format (Conventional Commits, full words):
  <type>/<scope>: <short summary>
Examples:
  feature/qcom_usbnet: add retry logic for transient errors
-->

## Description

  - Clear DeviceRemoveEvent before spawning I/O threads in QCPNP_SetupIoThreadsAndQueues to prevent worker threads from
  exiting immediately on re-enumeration due to a stale removal signal
  - Add QCDeviceGeneration DWORD registry value incremented on every EvtDevicePrepareHardware, allowing QDS to detect a
  device re-enumeration even when DevDesc/DevName/SerNum are identical across reboots
  - Move QCPNP_ReportDeviceName from EvtDeviceAdd to EvtDeviceD0Entry so the diag device name is re-announced to the
  parent filter driver on every re-enumeration, not just on first add

Fixes #

## Type of Change

<!-- Tick all that apply by replacing [ ] with [x]. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

 - Ran 500+ USB restart cycles on a composite device with fast boot time (~61ms re-enumeration)
  - Confirmed QCDeviceGeneration increments in HKLM\SYSTEM\CurrentControlSet\Control\Class\{4D36E978-E325-11CE-BFC1-08002BE10318}\<####> on each restart
  - Confirmed QUTS logs show departure and re-arrival for the diag port (COM4/COM7) on every cycle
  - Confirmed no regression on sibling ports (ADB, DPL, QDSS)

## Checklist

<!-- Replace [ ] with [x] for each item that's done. PRs missing items will be sent back for changes. -->

- [x] **All required CI checks are green** on the latest commit of this PR
- [x] **Build succeeds** following the steps in the [README](../README.md) / [src/linux/README.md](../src/linux/README.md)
- [x] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [x] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `<branch-prefix>/<area>/<description>`
- [x] PR title follows the Conventional Commits format with our full-word types (`feature` / `bugfix` / `hotfix` / `docs`)
- [x] I have performed a **self-review** of my own code
- [x] I have added **code comments** in areas that are complex or hard to understand
- [x] My changes generate **no new compiler warnings**
- [x] I have added **tests** for my fix or feature (or noted why tests are not feasible)
- [x] New and existing **tests pass locally** with my changes
- [x] My branch is **rebased onto the latest `develop`** (or `release/x.y` for hotfix) - no merge commits
- [x] Every commit has `Signed-off-by:` (DCO) - see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-guidelines)
- [x] I have **linked** the relevant issue if any (`Fixes #...`)
- [x] Any dependent changes have been merged and published in downstream modules
