### PR TITLE
ndis: fix invalid memory access to removed adapter during qmux broadcast

### DIFF
--- a/src/windows/ndis/MPIOC.c
+++ b/src/windows/ndis/MPIOC.c
@@ -2708,18 +2708,20 @@ PMPIOC_DEV_INFO MPIOC_FindIoDevice
          }
          else
          {
-#if 0
             if ((pIocDev->Adapter == NULL) ||
                 (pIocDev->Adapter->UsbRemoved == TRUE) ||
                 (pIocDev->Adapter->USBDo == NULL))
             {
+               if (IocDevice == pIocDev)
+               {
+                  bReferenceFound = TRUE;
+               }
                peekEntry = peekEntry->Flink;
                continue;
             }
-#endif
 
             pDevExt1 = pIocDev->Adapter->USBDo->DeviceExtension;
-            if (pAdapter != NULL)
+            if (pAdapter != NULL && pAdapter->USBDo != NULL)
             {
                pDevExt = (PDEVICE_EXTENSION)pAdapter->USBDo->DeviceExtension;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Qualcomm Open Source Project!
Please read CONTRIBUTING.md before submitting:
https://github.com/qualcomm/qcom-usb-kernel-drivers/blob/develop/CONTRIBUTING.md

Title format (Conventional Commits, full words):
  <type>/<scope>: <short summary>
Examples:
  feature/qcom_usbnet: add retry logic for transient errors
-->

## Description

A `SYSTEM_THREAD_EXCEPTION_NOT_HANDLED` (bugcheck 0x7E) kernel crash occurs when a USB WWAN device is unregistered while the driver is concurrently processing an inbound QMI indication message.

__Crash signature:__

```javascript
Failure.Bucket: AV_VRF_qcusbwwan!MPIOC_FindIoDevice
ExceptionCode:  c0000005 (Access violation - read from 0xffffffffffffffff)
Faulting line:  MPIOC.c @ 2721
Call stack:
  qcusbwwan!MPIOC_FindIoDevice
  qcusbwwan!MPQMI_SendQMUXToExternalClient
  qcusbwwan!MPQMI_ProcessInboundQMUX
  qcusbwwan!MPQMI_ProcessInboundQMI
  qcusbwwan!MPWork_ResolveRequests
  qcusbwwan!MPWork_WorkThread
```

`MPIOC_FindIoDevice` iterates the global `MP_DeviceList` to route inbound QMI messages to registered user-space clients. When called with `DeviceObject == NULL` (the QMI routing path), it unconditionally dereferences the pointer chain `pIocDev->Adapter->USBDo->DeviceExtension` for every list entry without first validating that the adapter is still alive.

During concurrent USB device removal, `pIocDev->Adapter` becomes a dangling pointer — the adapter object is freed but the `MPIOC_DEV_INFO` list entry still references it. The freed memory is subsequently reused (confirmed by crash dump: `rax = 0x0036003200370038`, a Unicode string pattern), causing the dereference chain to produce an invalid pointer (`0xffffffffffffffff`) and triggering the access violation.


## Type of Change

<!-- Tick all that apply by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

- Normal data call establishment, teardown, and QMI indication delivery are unaffected (no side effects).
- **Stress test for 3-4 concurrent devices is still needed.**

## Checklist

<!-- Replace [ ] with [x] for each item that's done. PRs missing items will be sent back for changes. -->

- [ ] **All required CI checks are green** on the latest commit of this PR
- [ ] **Build succeeds** following the steps in the [README](../README.md) / [src/linux/README.md](../src/linux/README.md)
- [ ] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [ ] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `<branch-prefix>/<area>/<description>`
- [ ] PR title follows the Conventional Commits format with our full-word types (`feature` / `bugfix` / `hotfix` / `docs`)
- [ ] I have performed a **self-review** of my own code
- [ ] I have added **code comments** in areas that are complex or hard to understand
- [ ] My changes generate **no new compiler warnings**
- [ ] I have added **tests** for my fix or feature (or noted why tests are not feasible)
- [ ] New and existing **tests pass locally** with my changes
- [ ] My branch is **rebased onto the latest `develop`** (or `release/x.y` for hotfix) - no merge commits
- [ ] Every commit has `Signed-off-by:` (DCO) - see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-guidelines)
- [ ] I have **linked** the relevant issue if any (`Fixes #...`)
- [ ] Any dependent changes have been merged and published in downstream modules
