### PR TITLE
Fixes for wdfserial warnings

### DIFF
--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -290,7 +290,7 @@ NTSTATUS QCPNP_IncrementGeneration(PDEVICE_CONTEXT pDevContext)
         return status;
     }
 
-    WdfRegistryQueryValue(key, &valueName, REG_DWORD, &genValue, sizeof(genValue), NULL);
+    WdfRegistryQueryValue(key, &valueName, sizeof(genValue), &genValue, NULL, NULL);
     WdfRegistryClose(key);
 
     genValue++;


### PR DESCRIPTION
<!--
Thank you for contributing to Qualcomm Open Source Project!
Please read CONTRIBUTING.md before submitting:
https://github.com/qualcomm/qcom-usb-kernel-drivers/blob/develop/CONTRIBUTING.md

Title format (Conventional Commits, full words):
  <type>/<scope>: <short summary>
Examples:
  feature/qcom_usbnet: add retry logic for transient errors
-->

## Description

  -Addressed warning coming in wdfserial driver

Fixes #

## Type of Change

<!-- Tick all that apply by replacing [ ] with [x]. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

 -Compiled the code without warnings

## Checklist

<!-- Replace [ ] with [x] for each item that's done. PRs missing items will be sent back for changes. -->

- [x] **All required CI checks are green** on the latest commit of this PR
- [x] **Build succeeds** following the steps in the [README](../README.md) / [src/linux/README.md](../src/linux/README.md)
- [x] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [x] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `<branch-prefix>/<area>/<description>`
- [x] PR title follows the Conventional Commits format with our full-word types (`feature` / `bugfix` / `hotfix` / `docs`)
- [x] I have performed a **self-review** of my own code
- [x] I have added **code comments** in areas that are complex or hard to understand
- [x] My changes generate **no new compiler warnings**
- [x] I have added **tests** for my fix or feature (or noted why tests are not feasible)
- [x] New and existing **tests pass locally** with my changes
- [x] My branch is **rebased onto the latest `develop`** (or `release/x.y` for hotfix) - no merge commits
- [x] Every commit has `Signed-off-by:` (DCO) - see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-guidelines)
- [x] I have **linked** the relevant issue if any (`Fixes #...`)
- [x] Any dependent changes have been merged and published in downstream modules
