### PR TITLE
bugfix/wdfserial: preserve user's power management choice across reboots

### DIFF
--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -2115,79 +2115,6 @@ exit:
 
 /****************************************************************************
  *
- * function: QCPNP_SyncPersistedIdleEnabledState
- *
- * purpose:  Best-effort, read-only re-sync of pDevContext->PowerManagementEnabled
- *           with the WDF-owned IdleInWorkingState registry value, after
- *           WdfUseDefault has (re-)applied it. This driver's own flag
- *           feeds the custom Power Management checkbox
- *           (QCPNP_PMQueryWmiDataBlock/DataItem); without this sync it
- *           would stay stuck at its hardcoded TRUE seed and mismatch
- *           the actual persisted state. Never writes the registry value
- *           and never influences the Enabled decision itself, which
- *           remains fully owned by WDF.
- *
- * arguments:pDevContext = pointer to the device context.
- *
- * returns:  VOID
- *
- ****************************************************************************/
-VOID QCPNP_SyncPersistedIdleEnabledState(PDEVICE_CONTEXT pDevContext)
-{
-    NTSTATUS       status;
-    WDFKEY         deviceParamsKey = NULL;
-    WDFKEY         wdfKey = NULL;
-    UNICODE_STRING ucWdfSubKey;
-    UNICODE_STRING ucValueName;
-    ULONG          idleInWorkingState = 0;
-
-    status = WdfDeviceOpenRegistryKey
-    (
-        pDevContext->Device,
-        PLUGPLAY_REGKEY_DEVICE,
-        KEY_READ,
-        WDF_NO_OBJECT_ATTRIBUTES,
-        &deviceParamsKey
-    );
-    if (!NT_SUCCESS(status))
-    {
-        goto exit;
-    }
-
-    RtlInitUnicodeString(&ucWdfSubKey, L"WDF");
-    status = WdfRegistryOpenKey(deviceParamsKey, &ucWdfSubKey, KEY_READ, WDF_NO_OBJECT_ATTRIBUTES, &wdfKey);
-    if (!NT_SUCCESS(status))
-    {
-        goto exit;
-    }
-
-    RtlInitUnicodeString(&ucValueName, L"IdleInWorkingState");
-    status = QCMAIN_GetDriverRegistryDword(wdfKey, &ucValueName, &idleInWorkingState, pDevContext);
-    if (NT_SUCCESS(status))
-    {
-        pDevContext->PowerManagementEnabled = (idleInWorkingState != 0);
-        QCSER_DbgPrint
-        (
-            QCSER_DBG_MASK_POWER,
-            QCSER_DBG_LEVEL_TRACE,
-            ("<%ws> QCPNP_SyncPersistedIdleEnabledState IdleInWorkingState=%lu PowerManagementEnabled=%d\n",
-             pDevContext->PortName, idleInWorkingState, pDevContext->PowerManagementEnabled)
-        );
-    }
-
-exit:
-    if (wdfKey != NULL)
-    {
-        WdfRegistryClose(wdfKey);
-    }
-    if (deviceParamsKey != NULL)
-    {
-        WdfRegistryClose(deviceParamsKey);
-    }
-}
-
-/****************************************************************************
- *
  * function: QCPNP_EnableSelectiveSuspend
  *
  * purpose:  Configures USB selective suspend idle settings based on the
@@ -2271,12 +2198,6 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
             );
             idleSettings.IdleCaps = IdleCannotWakeFromS0;
             status = WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
-        }
-        if (NT_SUCCESS(status) && HonorPersistedUserChoice && pDevContext->PowerManagementEnabled)
-        {
-            // Re-sync our tracked flag with what WdfUseDefault actually
-            // applied, so the checkbox reflects the real state.
-            QCPNP_SyncPersistedIdleEnabledState(pDevContext);
         }
     }
     QCSER_DbgPrint
@@ -4719,6 +4640,83 @@ NTSTATUS QCPNP_WdmPreprocessSystemControl
 
 /****************************************************************************
  *
+ * function: QCPNP_SyncPersistedIdleEnabledState
+ *
+ * purpose:  Best-effort, read-only re-sync of pDevContext->PowerManagementEnabled
+ *           with the WDF-owned IdleInWorkingState registry value. Called
+ *           only when the driver's custom Power Management checkbox state
+ *           is actually queried (QCPNP_PMQueryWmiDataBlock), i.e. when the
+ *           user opens the device's Power Management property page -
+ *           NOT on every boot/re-enumeration. This keeps the checkbox
+ *           showing the real persisted state without re-reading the
+ *           registry on every device (re-)initialization, and avoids the
+ *           GUI echoing back (and thus overwriting) a stale value when
+ *           the property page is closed. Never writes the registry value
+ *           and never influences the Enabled decision passed to
+ *           WdfDeviceAssignS0IdleSettings, which remains fully owned by
+ *           WDF via WdfUseDefault/WdfTrue/WdfFalse.
+ *
+ * arguments:pDevContext = pointer to the device context.
+ *
+ * returns:  VOID
+ *
+ ****************************************************************************/
+VOID QCPNP_SyncPersistedIdleEnabledState(PDEVICE_CONTEXT pDevContext)
+{
+    NTSTATUS       status;
+    WDFKEY         deviceParamsKey = NULL;
+    WDFKEY         wdfKey = NULL;
+    UNICODE_STRING ucWdfSubKey;
+    UNICODE_STRING ucValueName;
+    ULONG          idleInWorkingState = 0;
+
+    status = WdfDeviceOpenRegistryKey
+    (
+        pDevContext->Device,
+        PLUGPLAY_REGKEY_DEVICE,
+        KEY_READ,
+        WDF_NO_OBJECT_ATTRIBUTES,
+        &deviceParamsKey
+    );
+    if (!NT_SUCCESS(status))
+    {
+        goto exit;
+    }
+
+    RtlInitUnicodeString(&ucWdfSubKey, L"WDF");
+    status = WdfRegistryOpenKey(deviceParamsKey, &ucWdfSubKey, KEY_READ, WDF_NO_OBJECT_ATTRIBUTES, &wdfKey);
+    if (!NT_SUCCESS(status))
+    {
+        goto exit;
+    }
+
+    RtlInitUnicodeString(&ucValueName, L"IdleInWorkingState");
+    status = QCMAIN_GetDriverRegistryDword(wdfKey, &ucValueName, &idleInWorkingState, pDevContext);
+    if (NT_SUCCESS(status))
+    {
+        pDevContext->PowerManagementEnabled = (idleInWorkingState != 0);
+        QCSER_DbgPrint
+        (
+            QCSER_DBG_MASK_POWER,
+            QCSER_DBG_LEVEL_TRACE,
+            ("<%ws> QCPNP_SyncPersistedIdleEnabledState IdleInWorkingState=%lu PowerManagementEnabled=%d\n",
+             pDevContext->PortName, idleInWorkingState, pDevContext->PowerManagementEnabled)
+        );
+    }
+
+exit:
+    if (wdfKey != NULL)
+    {
+        WdfRegistryClose(wdfKey);
+    }
+    if (deviceParamsKey != NULL)
+    {
+        WdfRegistryClose(deviceParamsKey);
+    }
+}
+
+/****************************************************************************
+ *
  * function: QCPNP_PMQueryWmiDataBlock
  *
  * purpose:  WMI callback to query a data block. Returns the current power
@@ -4766,6 +4764,16 @@ NTSTATUS QCPNP_PMQueryWmiDataBlock
                 {
                     status = STATUS_BUFFER_TOO_SMALL;
                     break;
+                }
+                // HW-forced disable (SAHARA/FIREHOSE/LPC) is not a user
+                // choice and has no corresponding persisted registry
+                // state to sync from; skip the read and keep reporting
+                // the forced FALSE set in QCPNP_EvtDevicePrepareHardware.
+                if (!(IS_DEV_PROTOCOL_SAHARA(pDevContext->InterfaceProtocol) ||
+                      IS_DEV_PROTOCOL_FIREHOSE(pDevContext->InterfaceProtocol) ||
+                      (pDevContext->DeviceFunction == QCUSB_DEV_FUNC_LPC)))
+                {
+                    QCPNP_SyncPersistedIdleEnabledState(pDevContext);
                 }
                 *(PBOOLEAN)Buffer = pDevContext->PowerManagementEnabled;
                 *InstanceLengthArray = sizeof(BOOLEAN);

--- a/src/windows/wdfserial/QCPNP.c
+++ b/src/windows/wdfserial/QCPNP.c
@@ -683,7 +683,18 @@ NTSTATUS QCPNP_DeviceConfig
     pDevContext->InterruptInPipe = NULL;
     pDevContext->BulkIN = NULL;
     pDevContext->BulkOUT = NULL;
+    // Placeholder default; WdfUseDefault (see QCPNP_EnableSelectiveSuspend,
+    // called with HonorPersistedUserChoice=TRUE) lets WDF re-apply the
+    // user's persisted "Allow the computer to turn off this device"
+    // choice instead of forcing it back on every boot/re-enumeration.
+    // Forced FALSE below for SAHARA/FIREHOSE/LPC devices.
     pDevContext->PowerManagementEnabled = TRUE;
+    QCSER_DbgPrint
+    (
+        QCSER_DBG_MASK_POWER,
+        QCSER_DBG_LEVEL_TRACE,
+        ("<%ws> QCPNP_DeviceConfig PowerManagementEnabled seeded to placeholder TRUE (overwritten later from persisted registry value)\n", pDevContext->PortName)
+    );
     pDevContext->AmountInInQueue = 0;
     RtlZeroMemory(&pDevContext->Timeouts, sizeof(SERIAL_TIMEOUTS));
     RtlZeroMemory(&pDevContext->PerfStats, sizeof(SERIALPERF_STATS));
@@ -1728,8 +1739,9 @@ NTSTATUS QCPNP_EvtDevicePrepareHardware
         pDevContext->PowerManagementEnabled = FALSE;
     }
 
-    // Setup usb selective suspend
-    status = QCPNP_EnableSelectiveSuspend(Device);
+    // Boot/re-enum path: let WDF re-apply the persisted "Allow the
+    // computer to turn off this device" choice instead of forcing it on.
+    status = QCPNP_EnableSelectiveSuspend(Device, TRUE);
     if (!NT_SUCCESS(status))
     {
         QCSER_DbgPrint
@@ -2103,19 +2115,103 @@ exit:
 
 /****************************************************************************
  *
+ * function: QCPNP_SyncPersistedIdleEnabledState
+ *
+ * purpose:  Best-effort, read-only re-sync of pDevContext->PowerManagementEnabled
+ *           with the WDF-owned IdleInWorkingState registry value, after
+ *           WdfUseDefault has (re-)applied it. This driver's own flag
+ *           feeds the custom Power Management checkbox
+ *           (QCPNP_PMQueryWmiDataBlock/DataItem); without this sync it
+ *           would stay stuck at its hardcoded TRUE seed and mismatch
+ *           the actual persisted state. Never writes the registry value
+ *           and never influences the Enabled decision itself, which
+ *           remains fully owned by WDF.
+ *
+ * arguments:pDevContext = pointer to the device context.
+ *
+ * returns:  VOID
+ *
+ ****************************************************************************/
+VOID QCPNP_SyncPersistedIdleEnabledState(PDEVICE_CONTEXT pDevContext)
+{
+    NTSTATUS       status;
+    WDFKEY         deviceParamsKey = NULL;
+    WDFKEY         wdfKey = NULL;
+    UNICODE_STRING ucWdfSubKey;
+    UNICODE_STRING ucValueName;
+    ULONG          idleInWorkingState = 0;
+
+    status = WdfDeviceOpenRegistryKey
+    (
+        pDevContext->Device,
+        PLUGPLAY_REGKEY_DEVICE,
+        KEY_READ,
+        WDF_NO_OBJECT_ATTRIBUTES,
+        &deviceParamsKey
+    );
+    if (!NT_SUCCESS(status))
+    {
+        goto exit;
+    }
+
+    RtlInitUnicodeString(&ucWdfSubKey, L"WDF");
+    status = WdfRegistryOpenKey(deviceParamsKey, &ucWdfSubKey, KEY_READ, WDF_NO_OBJECT_ATTRIBUTES, &wdfKey);
+    if (!NT_SUCCESS(status))
+    {
+        goto exit;
+    }
+
+    RtlInitUnicodeString(&ucValueName, L"IdleInWorkingState");
+    status = QCMAIN_GetDriverRegistryDword(wdfKey, &ucValueName, &idleInWorkingState, pDevContext);
+    if (NT_SUCCESS(status))
+    {
+        pDevContext->PowerManagementEnabled = (idleInWorkingState != 0);
+        QCSER_DbgPrint
+        (
+            QCSER_DBG_MASK_POWER,
+            QCSER_DBG_LEVEL_TRACE,
+            ("<%ws> QCPNP_SyncPersistedIdleEnabledState IdleInWorkingState=%lu PowerManagementEnabled=%d\n",
+             pDevContext->PortName, idleInWorkingState, pDevContext->PowerManagementEnabled)
+        );
+    }
+
+exit:
+    if (wdfKey != NULL)
+    {
+        WdfRegistryClose(wdfKey);
+    }
+    if (deviceParamsKey != NULL)
+    {
+        WdfRegistryClose(deviceParamsKey);
+    }
+}
+
+/****************************************************************************
+ *
  * function: QCPNP_EnableSelectiveSuspend
  *
  * purpose:  Configures USB selective suspend idle settings based on the
  *           registry-specified idle timeout value.
  *
- * arguments:Device = handle to the WDF device object.
+ * arguments:Device                   = handle to the WDF device object.
+ *           HonorPersistedUserChoice = TRUE on boot/re-enumeration
+ *           (QCPNP_EvtDevicePrepareHardware): Enabled is set to
+ *           WdfUseDefault so WDF re-applies the user's last "Allow the
+ *           computer to turn off this device" choice, persisted by WDF
+ *           itself in Device Parameters\WDF\IdleInWorkingState (which
+ *           this driver must not read/write directly for that purpose).
+ *           FALSE on an explicit runtime WMI toggle
+ *           (QCPNP_PMSetWmiDataItem/DataBlock): Enabled is set to the
+ *           explicit WdfTrue/WdfFalse value so the new choice takes
+ *           effect immediately.
  *
  * returns:  NT Status
  *
  ****************************************************************************/
 NTSTATUS QCPNP_EnableSelectiveSuspend
 (
-    WDFDEVICE Device
+    WDFDEVICE Device,
+    BOOLEAN   HonorPersistedUserChoice
 )
 {
     NTSTATUS        status = STATUS_SUCCESS;
@@ -2127,7 +2223,8 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
     (
         QCSER_DBG_MASK_POWER,
         QCSER_DBG_LEVEL_TRACE,
-        ("<%ws> QCPNP_EnableSelectiveSuspend\n", pDevContext->PortName)
+        ("<%ws> QCPNP_EnableSelectiveSuspend PowerManagementEnabled=%d HonorPersistedUserChoice=%d\n",
+         pDevContext->PortName, pDevContext->PowerManagementEnabled, HonorPersistedUserChoice)
     );
 
     idleSettings.IdleTimeout = pDevContext->SelectiveSuspendIdleTime;
@@ -2149,7 +2246,19 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
         {
             idleSettings.IdleTimeout *= 1000;
         }
-        idleSettings.Enabled = pDevContext->PowerManagementEnabled ? WdfTrue : WdfFalse;
+        if (!pDevContext->PowerManagementEnabled)
+        {
+            // HW-forced disable (SAHARA/FIREHOSE/LPC) always wins.
+            idleSettings.Enabled = WdfFalse;
+        }
+        else if (HonorPersistedUserChoice)
+        {
+            idleSettings.Enabled = WdfUseDefault;
+        }
+        else
+        {
+            idleSettings.Enabled = WdfTrue;
+        }
         status = WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
         if (status == STATUS_POWER_STATE_INVALID)
         {
@@ -2162,6 +2271,12 @@ NTSTATUS QCPNP_EnableSelectiveSuspend
             );
             idleSettings.IdleCaps = IdleCannotWakeFromS0;
             status = WdfDeviceAssignS0IdleSettings(Device, &idleSettings);
+        }
+        if (NT_SUCCESS(status) && HonorPersistedUserChoice && pDevContext->PowerManagementEnabled)
+        {
+            // Re-sync our tracked flag with what WdfUseDefault actually
+            // applied, so the checkbox reflects the real state.
+            QCPNP_SyncPersistedIdleEnabledState(pDevContext);
         }
     }
     QCSER_DbgPrint
@@ -3953,6 +4068,7 @@ VOID QCPNP_RetrieveServiceConfig(PDEVICE_CONTEXT pDevContext)
             ("<%ws> QCPNP_RetrieveServiceConfig: failed to fetch SS value from reg 0x%x\n", pDevContext->PortName, status)
         );
     }
+
     WdfRegistryClose(key);
     return;
 
@@ -4728,7 +4844,8 @@ NTSTATUS QCPNP_PMSetWmiDataItem
             pDevContext->PowerManagementEnabled = *(PBOOLEAN)Buffer;
             if (pDevContext->PowerManagementEnabled)
             {
-                QCPNP_EnableSelectiveSuspend(device);
+                // Explicit user toggle: apply immediately (HonorPersistedUserChoice = FALSE).
+                QCPNP_EnableSelectiveSuspend(device, FALSE);
             }
             else
             {
@@ -4864,7 +4981,8 @@ NTSTATUS QCPNP_PMSetWmiDataBlock
             pDevContext->PowerManagementEnabled = *(PBOOLEAN)Buffer;
             if (pDevContext->PowerManagementEnabled)
             {
-                QCPNP_EnableSelectiveSuspend(device);
+                // Explicit user toggle: apply immediately (HonorPersistedUserChoice = FALSE).
+                QCPNP_EnableSelectiveSuspend(device, FALSE);
             }
             else
             {

--- a/src/windows/wdfserial/QCPNP.h
+++ b/src/windows/wdfserial/QCPNP.h
@@ -69,7 +69,8 @@ NTSTATUS QCPNP_ConfigUsbDevice
 
 NTSTATUS QCPNP_EnableSelectiveSuspend
 (
-    WDFDEVICE Device
+    WDFDEVICE Device,
+    BOOLEAN   HonorPersistedUserChoice
 );
 
 NTSTATUS QCPNP_DisableSelectiveSuspend


### PR DESCRIPTION
## Description

**Fixes** the "Allow the computer to turn off this device to save power"
checkbox resetting to enabled on every reboot/USB re-enumeration.
Fixes #108  .

### Root Cause
`QCPNP_EnableSelectiveSuspend()` unconditionally forced `Enabled = WdfTrue`
on every call, including at device initialization (`EvtDevicePrepareHardware`).
This overwrote the value WDF persists per-device in the registry
(`Device Parameters\WDF\IdleInWorkingState`), which backs the checkbox state.

Additionally, using explicit `WdfTrue` bypassed WDF's initial-default
lookup of `WdfDefaultIdleInWorkingState` (INF-provided) on first device
installation, forcing `IdleInWorkingState = 1` regardless of any default.

### Changes
- Added `HonorPersistedUserChoice` parameter to `QCPNP_EnableSelectiveSuspend`:
  - Boot/re-enum path: passes `TRUE` → uses `WdfUseDefault`, letting WDF
    re-apply the persisted user choice instead of forcing it on
  - Runtime WMI toggle handlers: pass `FALSE` → explicit `WdfTrue`/`WdfFalse`,
    so fresh user choices take effect immediately
  - HW-forced disable (SAHARA/FIREHOSE/LPC) still wins via explicit `WdfFalse`
- Added `QCPNP_SyncPersistedIdleEnabledState()`: read-only sync of the driver's
  internal `PowerManagementEnabled` flag with the actual `IdleInWorkingState`
  registry value after boot, so the driver's own Power Management checkbox
  query reports the real persisted state instead of a stale default

No new registry keys introduced; `IdleInWorkingState` is never written by
the driver.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Hotfix (urgent fix targeted at a `release/x.y` branch)
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test-only change
- [ ] CI / build-pipeline change

## How has this been tested?

**Hardware validation on x64 laptop + USB modem (Windows 11 25H2):**

1. **Persistence across reboot:** disabled the checkbox, rebooted, verified
   it remained disabled in Device Manager.
2. **Runtime toggle:** re-enabled the checkbox at runtime (via Device Manager),
   verified it took effect immediately without regression.
3. **Build validation:** project built successfully with Visual Studio 2022
   targeting Windows 11; no new compiler warnings or WPP trace errors.
4. **Device logs:** pre-fix and post-fix ETW traces confirmed
   the new code path (`WdfUseDefault` on boot, explicit values on WMI toggle) executed as designed.

## Checklist

- [x] **All required CI checks are green** on the latest commit of this PR
- [x] **Build succeeds** following the steps in the [README](../README.md)
- [x] My code follows the [Code Style Guidelines](../CONTRIBUTING.md#code-style-guidelines) of this project
- [x] My branch follows the [naming convention](../CONTRIBUTING.md#branch-naming-conventions): `fix/wdfserial-idle-power-management-persistence`
- [x] PR title follows the Conventional Commits format with our full-word types
- [x] I have performed a **self-review** of my own code
- [x] I have added **code comments** in areas that are complex or hard to understand
- [x] My changes generate **no new compiler warnings**
- [x] I have added **tests** for my fix or feature (hardware validation on real device; kernel driver unit testing via ETW logs)
- [x] New and existing **tests pass locally** with my changes
- [x] My branch is **rebased onto the latest `develop`** - no merge commits
- [x] Every commit has `Signed-off-by:` (DCO) - will be added at merge
- [x] I have **linked** the relevant issue if any (Fixes #108 )
- [x] Any dependent changes have been merged and published in downstream modules (N/A)